### PR TITLE
Use sum-based karma pool for dice purchases

### DIFF
--- a/module/svelte/apps/components/RollComposerComponent.svelte
+++ b/module/svelte/apps/components/RollComposerComponent.svelte
@@ -13,9 +13,14 @@
       StoreManager.Unsubscribe(actor);
    });
 
-   let karmaPoolStore = actorStoreManager.GetRWStore("karma.karmaPool.value");
+   let karmaPoolStore = actorStoreManager.GetSumROStore("karma.karmaPool");
    let penalty = actorStoreManager.GetRWStore("health.penalty");
-   let karmaPoolBacking = $karmaPoolStore;
+
+   let maxDice = $state(0);
+   $effect(() => {
+      const k = $karmaPoolStore.sum;
+      maxDice = Math.floor((Math.sqrt(8 * k + 1) - 1) / 2);
+   });
 
    let currentDicePoolSelectionStore = actorStoreManager.GetShallowStore(actor.id, stores.dicepoolSelection);
    let currentDicePoolName = $state("");
@@ -194,6 +199,8 @@
       if (isInCombat) {
          const combat = game.combat;
       }
+
+      if (karmaCost > $karmaPoolStore.sum) return;
 
       if (karmaCost > 0) {
          const karmaEffect = {
@@ -421,7 +428,7 @@
             class="karma-counter"
             bind:value={diceBought}
             min={0}
-            max={actor.system.karma.karmaPool.value}
+            max={maxDice}
             onIncrement={KarmaCostCalculator}
             onDecrement={KarmaCostCalculator}
          />


### PR DESCRIPTION
## Summary
- Switch karma pool to sum-based store and compute available karma dice
- Cap karma expenditures with a dynamic limit and overspend guard

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Could not resolve "../../svelte/apps/metatypeApp.svelte" from "module/foundry/sheets/MetatypeItemSheet.js")*

------
https://chatgpt.com/codex/tasks/task_e_688dcff134648325aaad497933de9e50