### PR TITLE
fix: enable opposed roll resolution

### DIFF
--- a/sr3e.js
+++ b/sr3e.js
@@ -382,6 +382,22 @@ function registerHooks() {
 
    Hooks.once("ready", () => {
       game.socket.on("system.sr3e", async ({ action, data }) => {
+         if (action === "opposeRoll") {
+            if (data.targetUserId !== game.user.id) return;
+
+            const initiator = game.actors.get(data.initiatorId);
+            const target = game.actors.get(data.targetId);
+            if (!initiator || !target) return;
+
+            OpposeRollService.registerContest({
+               contestId: data.contestId,
+               initiator,
+               target,
+               rollData: data.rollData,
+            });
+            return;
+         }
+
          if (action !== "resolveOpposedRoll") return;
 
          const contest = OpposeRollService.getContestById(data.contestId);


### PR DESCRIPTION
## Summary
- ensure both clients register an opposed roll and handle resolution

## Testing
- `npm test` (fails: Missing script)
- `npm run build` (fails: Could not resolve svelte/apps/metatypeApp.svelte)


------
https://chatgpt.com/codex/tasks/task_e_688f475d7a6083258cfd62ee77b14e85