### PR TITLE
Refactor opposed roll state to chat messages

### DIFF
--- a/module/foundry/documents/SR3EChatMessage.js
+++ b/module/foundry/documents/SR3EChatMessage.js
@@ -1,1 +1,22 @@
-export class SR3EChatMessage extends ChatMessage
+export default class SR3EChatMessage extends ChatMessage {
+   getOpposedData() {
+      return this.flags?.sr3e?.opposed;
+   }
+
+   isResolved() {
+      return this.getOpposedData()?.resolved ?? false;
+   }
+
+   async markResolved(update = {}) {
+      const data = foundry.utils.mergeObject(this.getOpposedData() ?? {}, update);
+      data.resolved = true;
+      data.pending = false;
+      return this.update({ [`flags.sr3e.opposed`]: data });
+   }
+
+   static Register() {
+      CONFIG.ChatMessage.documentClass = SR3EChatMessage;
+      console.log("sr3e /// ---> SR3EChatMessage registered");
+   }
+}
+

--- a/module/foundry/documents/SR3ERoll.js
+++ b/module/foundry/documents/SR3ERoll.js
@@ -78,7 +78,8 @@ export default class SR3ERoll extends Roll {
 
          await new Promise((resolve) => {
             const checkInterval = setInterval(() => {
-               if (!OpposeRollService.getContestById(contestId)) {
+               const contest = OpposeRollService.getContestById(contestId);
+               if (!contest || contest.resolved || contest.aborted) {
                   clearInterval(checkInterval);
                   resolve();
                }
@@ -91,7 +92,10 @@ export default class SR3ERoll extends Roll {
       if (Array.isArray(this._waitingOn)) {
          await new Promise((resolve) => {
             const checkInterval = setInterval(() => {
-               const unresolved = this._waitingOn.filter((id) => OpposeRollService.getContestById(id));
+               const unresolved = this._waitingOn.filter((id) => {
+                  const contest = OpposeRollService.getContestById(id);
+                  return contest && !contest.resolved && !contest.aborted;
+               });
                if (unresolved.length === 0) {
                   clearInterval(checkInterval);
                   resolve();

--- a/module/svelte/apps/components/RollComposerComponent.svelte
+++ b/module/svelte/apps/components/RollComposerComponent.svelte
@@ -210,7 +210,6 @@
       console.log("Challenge: All contests resolved.");
       await CommitEffects();
       Hooks.callAll("actorSystemRecalculated", actor);
-      OpposeRollService.expireContest(roll.options.contestId);
       visible = false;
    }
 
@@ -236,17 +235,13 @@
 
       await roll.evaluate({ suppressMessage: true });
 
-      const contest = OpposeRollService.getContestById(caller.contestId);
-      const initiatorUser = OpposeRollService.resolveControllingUser(contest.initiator);
-
-      await initiatorUser.query("sr3e.resolveOpposedRoll", {
+      await CONFIG.queries["sr3e.resolveOpposedRoll"]({
          contestId: caller.contestId,
          rollData: roll.toJSON(),
       });
 
       await CommitEffects();
       visible = false;
-      OpposeRollService.expireContest(caller.contestId);
       Hooks.callAll("actorSystemRecalculated", actor);
    }
 


### PR DESCRIPTION
## Summary
- Store opposed roll contests entirely on chat message flags
- Update query handlers and chat render hook for chat-driven contest resolution
- Simplify roll composer and roll waiting logic to use CONFIG.queries directly

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68930a2b577c8325a6f5d6138c58c2c6