### PR TITLE
fix recoil update recursion

### DIFF
--- a/module/svelte/apps/components/RollComposerComponent.svelte
+++ b/module/svelte/apps/components/RollComposerComponent.svelte
@@ -261,15 +261,20 @@
       if (caller?.type !== "item") return;
 
       const recoil = FirearmService.getRecoilModifier({ actor, caller, preview: true });
-      const withoutRecoil = modifiersArray.filter((m) => m.id !== "recoil");
+      const idx = modifiersArray.findIndex((m) => m.id === "recoil");
 
       if (recoil) {
-         const changed =
-            withoutRecoil.length !== modifiersArray.length ||
-            !withoutRecoil.some((m) => m.id === "recoil" && m.value === recoil.value);
-         if (changed) modifiersArray = [...withoutRecoil, recoil];
-      } else if (withoutRecoil.length !== modifiersArray.length) {
-         modifiersArray = withoutRecoil;
+         if (idx === -1) {
+            modifiersArray = [...modifiersArray, recoil];
+         } else if (modifiersArray[idx]?.value !== recoil.value) {
+            const copy = [...modifiersArray];
+            copy[idx] = recoil;
+            modifiersArray = copy;
+         }
+      } else if (idx !== -1) {
+         const copy = [...modifiersArray];
+         copy.splice(idx, 1);
+         modifiersArray = copy;
       }
    });
 


### PR DESCRIPTION
## Summary
- guard recoil modifier effect to avoid infinite updates

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: Could not resolve '../../svelte/apps/metatypeApp.svelte')*

------
https://chatgpt.com/codex/tasks/task_e_6898bcaa30dc832585910c8d507ebba5