### PR TITLE
feat: add damage resistance roll hook

### DIFF
--- a/module/foundry/sheets/CharacterActorSheet.js
+++ b/module/foundry/sheets/CharacterActorSheet.js
@@ -241,7 +241,14 @@ export default class CharacterActorSheet extends foundry.applications.sheets.Act
          payload = { ...payload, type: "attribute", item: undefined };
       }
 
-      this.#composer.setCallerData(payload, { visible: true });
+      payload = {
+         ...payload,
+         isResistingDamage: callerData?.isResistingDamage,
+         prep: callerData?.prep,
+         weaponId: callerData?.weaponId,
+      };
+
+      this.#composer.setCallerData(payload, options ?? { visible: true });
    }
 
    _onSubmit() {

--- a/module/svelte/apps/components/RollComposerComponent.svelte
+++ b/module/svelte/apps/components/RollComposerComponent.svelte
@@ -195,6 +195,8 @@
    export function setCallerData(callerData, options = {}) {
       resetToDefaults();
       Object.assign(caller, callerData);
+      caller.prep = callerData?.prep;
+      caller.weaponId = callerData?.weaponId;
 
       const dict = CONFIG?.sr3e?.attributes ?? {};
       if (caller.responseMode && caller.type !== "attribute") {
@@ -210,6 +212,7 @@
 
       if (options.visible !== undefined) visible = options.visible;
       isResponding = caller.responseMode || false;
+      isResistingDamage = callerData?.isResistingDamage || false;
       hasTarget = game.user.targets.size > 0;
 
       modifiersArray = [];


### PR DESCRIPTION
## Summary
- hook renderChatMessageHTML to parse `.sr3e-resist-damage-button` and open Body-based resistance rolls
- forward resistance context through CharacterActorSheet and roll composer

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Could not resolve "../../svelte/apps/metatypeApp.svelte" from "module/foundry/sheets/MetatypeItemSheet.js")*

------
https://chatgpt.com/codex/tasks/task_e_689ae56f56e0832582a7c28eb3e3a0d3