### PR TITLE
Handle unrecognized weapon families as melee

### DIFF
--- a/module/services/OpposeRollService.js
+++ b/module/services/OpposeRollService.js
@@ -11,9 +11,9 @@ export default class OpposeRollService {
     if (!weapon || weapon.type !== "weapon") throw new Error("sr3e: weapon required");
     const fam = String(weapon.system?.family || "").toLowerCase();
     if (fam === "firearm") return { key: "firearm", svc: FirearmService };
-    if (fam === "melee" || fam === "bladed") return { key: "melee", svc: MeleeService };
+    if (fam) return { key: "melee", svc: MeleeService };
 
-    // heuristic
+    // heuristic fallback when no family is declared
     const hasAmmo = !!weapon.system?.ammunitionClass || !!weapon.system?.ammoId;
     if (hasAmmo) return { key: "firearm", svc: FirearmService };
     if (Number.isFinite(weapon.system?.reach) || Number.isFinite(weapon.system?.powerAdd)) {


### PR DESCRIPTION
## Summary
- Default unknown weapon families to the melee service to avoid crash when weapon family is set to values like "Sword"

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Could not resolve "../../svelte/apps/metatypeApp.svelte" from "module/foundry/sheets/MetatypeItemSheet.js")*

------
https://chatgpt.com/codex/tasks/task_e_689b349ae620832596a31f2431b2377e