### PR TITLE
fix: ensure range TN modifier appears during challenge

### DIFF
--- a/module/svelte/apps/components/RollComposerComponent.svelte
+++ b/module/svelte/apps/components/RollComposerComponent.svelte
@@ -25,6 +25,7 @@
       $shouldDisplaySheen = false;
       StoreManager.Unsubscribe(actor);
       if (unhook) Hooks.off("updateCombat", unhook);
+      if (targetHook) Hooks.off("targetToken", targetHook);
    });
 
    let karmaPoolSumStore = actorStoreManager.GetSumROStore("karma.karmaPool");
@@ -394,6 +395,7 @@
 
    // ------------------- lifecycle / hooks -------------------
    let unhook = null;
+   let targetHook = null;
    onMount(() => {
       const refreshPhase = () => {
          const { key } = FirearmService.getPhase();
@@ -407,6 +409,12 @@
       Hooks.on("updateCombat", unhook);
       // initialize once
       phaseKey = FirearmService.getPhase().key;
+
+      // react to target acquisition/clear
+      targetHook = () => {
+         hasTarget = game.user.targets.size > 0;
+      };
+      Hooks.on("targetToken", targetHook);
    });
 
    // ------------------- reactivity -------------------


### PR DESCRIPTION
## Summary
- update roll composer to track target changes via `targetToken` hook
- ensure range modifiers apply when challenge flow begins

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689cd1c81540832583181b369d68d776