### PR TITLE
Default dodge for opposed rolls

### DIFF
--- a/module/foundry/hooks/renderChatMessageHTML/addOpposedResponseButton.js
+++ b/module/foundry/hooks/renderChatMessageHTML/addOpposedResponseButton.js
@@ -86,6 +86,8 @@ export async function addOpposedResponseButton(message, html, data) {
       const actorSheet = current.target.sheet;
       if (!actorSheet.rendered) await actorSheet.render(true);
 
+      const { tnMod = 0, tnLabel = "Weapon difficulty" } = current?.defenseHint ?? {};
+
       const caller = {
          type: "dodge",
          key: "dodge",
@@ -94,6 +96,8 @@ export async function addOpposedResponseButton(message, html, data) {
          value: 0,
          responseMode: true, // Composer: response flow
          contestId,
+         defenseTNMod: tnMod,
+         defenseTNLabel: tnLabel,
       };
 
       actorSheet.setRollComposerData(caller);

--- a/module/foundry/sheets/CharacterActorSheet.js
+++ b/module/foundry/sheets/CharacterActorSheet.js
@@ -227,7 +227,12 @@ export default class CharacterActorSheet extends foundry.applications.sheets.Act
       if (payload?.responseMode) {
          const contest = payload.contestId ? OpposeRollService.getContestById(payload.contestId) : null;
          const hint = contest?.defenseHint ?? OpposeRollService.getDefaultDefenseHint(contest?.initiatorRoll);
-         if (hint?.type === "attribute") {
+
+         if (payload.type === "dodge") {
+            if (payload.defenseTNMod === undefined) payload.defenseTNMod = Number(hint?.tnMod || 0);
+            if (payload.defenseTNLabel === undefined)
+               payload.defenseTNLabel = hint?.tnLabel || "Weapon difficulty";
+         } else if (hint?.type === "attribute") {
             payload.type = "attribute";
             payload.key = hint.key;
             payload.name = game.i18n.localize(`sr3e.attributes.${hint.key}`) || hint.key;

--- a/module/svelte/apps/components/RollComposerComponent.svelte
+++ b/module/svelte/apps/components/RollComposerComponent.svelte
@@ -319,6 +319,8 @@
             caller.skillId = undefined;
             caller.linkedAttribute = undefined;
             caller.dice = Number(caller.dice) || 0;
+            associatedDicePoolString = "combat";
+            associatedDicePoolStore = actorStoreManager.GetRWStore(`dicePools.${associatedDicePoolString}`);
 
             // IMPORTANT: do not fall through; keep Dodge pure (no Reaction coercion).
             return;


### PR DESCRIPTION
## Summary
- Preload Dodge response with weapon TN modifiers when players accept a dodge prompt
- Preserve Dodge roll setup in character sheet, only applying attribute hints when relevant
- Default the roll composer to Combat Pool dice for dodge responses

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Could not resolve "../../svelte/apps/metatypeApp.svelte")

------
https://chatgpt.com/codex/tasks/task_e_689d9373351c8325b9459341e4687a58