### PR TITLE
Apply dodge successes as negative TN modifier

### DIFF
--- a/module/services/OpposeRollService.js
+++ b/module/services/OpposeRollService.js
@@ -259,6 +259,7 @@ export default class OpposeRollService {
       if (!attackContext) attackContext = this.#ensureAttackContext(contest);
 
       const netSuccesses = this.computeNetSuccesses(initiatorRoll, targetRoll);
+      const dodgeSuccesses = this.getSuccessCount(targetRoll);
       const winner = netSuccesses > 0 ? initiator : target;
 
       let damageText = "";
@@ -276,10 +277,12 @@ export default class OpposeRollService {
                     plan: attackContext.plan,
                     damage: attackContext.damage,
                     netAttackSuccesses: netSuccesses,
+                    dodgeSuccesses,
                  })
                : svc.prepareDamageResolution(target, {
                     packet: attackContext.damage,
                     netAttackSuccesses: netSuccesses,
+                    dodgeSuccesses,
                  });
 
          // annotate for later (so we don't need to refetch/guess)

--- a/module/services/procedure/families/FirearmService.js
+++ b/module/services/procedure/families/FirearmService.js
@@ -169,9 +169,9 @@ export default class FirearmService {
       return { plan, damage, ammoId: ammo?.id || "" };
    }
 
-   static prepareDamageResolution(defender, { plan, damage, netAttackSuccesses = 0 } = {}) {
+   static prepareDamageResolution(defender, { plan, damage, netAttackSuccesses = 0, dodgeSuccesses = 0 } = {}) {
       DEBUG && LOG.info("", [__FILE__, __LINE__, FirearmService.prepareDamageResolution.name]);
-      return ResistanceEngine.build(defender, damage, netAttackSuccesses);
+      return ResistanceEngine.build(defender, damage, netAttackSuccesses, dodgeSuccesses);
    }
 
    static resolveDamageOutcome(build, bodySuccesses = 0) {

--- a/module/services/procedure/families/MeleeService.js
+++ b/module/services/procedure/families/MeleeService.js
@@ -40,9 +40,9 @@ export default class MeleeService {
       };
    }
 
-   static prepareDamageResolution(defender, { packet, netAttackSuccesses = 0 } = {}) {
+   static prepareDamageResolution(defender, { packet, netAttackSuccesses = 0, dodgeSuccesses = 0 } = {}) {
       DEBUG && LOG.info("", [__FILE__, __LINE__, MeleeService.prepareDamageResolution.name]);
-      return ResistanceEngine.build(defender, packet, netAttackSuccesses);
+      return ResistanceEngine.build(defender, packet, netAttackSuccesses, dodgeSuccesses);
    }
 
    static resolveDamageOutcome(build, bodySuccesses = 0) {


### PR DESCRIPTION
## Summary
- subtract defender's dodge successes from damage resistance TN
- propagate dodge success count through attack resolution

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Could not resolve "../../svelte/apps/metatypeApp.svelte")


------
https://chatgpt.com/codex/tasks/task_e_689db60b90608325b43995651eb1a587