### PR TITLE
feat: show dodge and defense modifiers

### DIFF
--- a/module/services/OpposeRollService.js
+++ b/module/services/OpposeRollService.js
@@ -292,11 +292,22 @@ export default class OpposeRollService {
          prep.weaponId = attackContext.weaponId || null; // <—
          prep.weaponName = attackContext.weaponName || weapon?.name || "Attack"; // <—
 
-         damageText = `
+        const dodgeMod = dodgeSuccesses > 0 ? -Math.floor(dodgeSuccesses / 2) : 0;
+        const power = attackContext.damage?.power ?? 0;
+        const armorType = prep.armor?.armorType;
+        const armorEff = prep.armor?.effective ?? 0;
+
+        damageText = `
         <p><strong>${target.name}</strong> must resist
         <strong>${prep.stagedStepBeforeResist.toUpperCase()}</strong> damage
-        (${prep.trackKey}) from <em>${prep.weaponName}</em>.
-        Resistance TN: <b>${prep.tn}</b>.</p>`;
+        (${prep.trackKey}) from <em>${prep.weaponName}</em>.</p>
+        <ul>
+          <li>Dodge successes: <b>${dodgeSuccesses}</b> (${dodgeMod})</li>
+          <li>Attack Power: <b>${power}</b></li>
+          <li>Armor (${armorType}): <b>-${armorEff}</b></li>
+        </ul>
+        ${OpposeRollService.renderTN(prep)}
+        `;
 
          resistancePayload = {
             contestId,


### PR DESCRIPTION
## Summary
- show dodge successes, attack power, and armor modifiers when resolving opposed rolls

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Could not resolve "../../svelte/apps/metatypeApp.svelte" from "module/foundry/sheets/MetatypeItemSheet.js")

------
https://chatgpt.com/codex/tasks/task_e_689dc00170908325b38fe22347e409cd