### PR TITLE
Route no-dodge resolution to initiator

### DIFF
--- a/module/foundry/hooks/renderChatMessageHTML/addOpposedResponseButton.js
+++ b/module/foundry/hooks/renderChatMessageHTML/addOpposedResponseButton.js
@@ -109,11 +109,10 @@ export async function addOpposedResponseButton(message, html, data) {
       });
 
       // Mark message so we do not offer buttons again on re-render
-      try {
-         await message.update({ flags: { sr3e: { opposedResponded: true } } });
-      } catch (e) {
-         console.warn("[sr3e] Unable to set opposedResponded flag:", e);
-      }
+      const messageId = message.id;
+      const authorUser = game.users.get(game.messages.get(messageId)?.user?.id);
+      if (authorUser)
+         authorUser.query("sr3e.markOpposedResponded", { messageId });
    };
 
    // --- NO: skip Dodge (0 successes) and continue immediately ---
@@ -135,17 +134,13 @@ export async function addOpposedResponseButton(message, html, data) {
       noBtn.classList.add("responded");
 
       // Empty rollData → getSuccessCount = 0 for defender
-      await CONFIG.queries["sr3e.resolveOpposedNoDodgeRemote"]({
-         contestId,
-         initiatorId: current.initiator.id,
-      });
+      await CONFIG.queries["sr3e.resolveOpposedNoDodge"]({ contestId });
 
       // Mark message so we do not offer buttons again on re-render
-      try {
-         await message.update({ flags: { sr3e: { opposedResponded: true } } });
-      } catch (e) {
-         console.warn("[sr3e] Unable to set opposedResponded flag:", e);
-      }
+      const messageId = message.id;
+      const authorUser = game.users.get(game.messages.get(messageId)?.user?.id);
+      if (authorUser)
+         authorUser.query("sr3e.markOpposedResponded", { messageId });
    };
 
 }


### PR DESCRIPTION
## Summary
- Route no-dodge contest resolution through the initiating user
- Allow only message owners/GM to mark opposed messages as responded
- Update opponent response buttons to use new queries

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Could not resolve "../../svelte/apps/metatypeApp.svelte")*

------
https://chatgpt.com/codex/tasks/task_e_689debfa67c083258fe57b978848ce47