### PR TITLE
Replace deprecated ChatMessage user field

### DIFF
--- a/module/foundry/hooks/renderChatMessageHTML/addOpposedResponseButton.js
+++ b/module/foundry/hooks/renderChatMessageHTML/addOpposedResponseButton.js
@@ -110,7 +110,7 @@ export async function addOpposedResponseButton(message, html, data) {
 
       // Mark message so we do not offer buttons again on re-render
       const messageId = message.id;
-      const authorUser = game.users.get(game.messages.get(messageId)?.user?.id);
+      const authorUser = game.messages.get(messageId)?.author;
       if (authorUser)
          authorUser.query("sr3e.markOpposedResponded", { messageId });
    };
@@ -138,7 +138,7 @@ export async function addOpposedResponseButton(message, html, data) {
 
       // Mark message so we do not offer buttons again on re-render
       const messageId = message.id;
-      const authorUser = game.users.get(game.messages.get(messageId)?.user?.id);
+      const authorUser = game.messages.get(messageId)?.author;
       if (authorUser)
          authorUser.query("sr3e.markOpposedResponded", { messageId });
    };


### PR DESCRIPTION
## Summary
- update addOpposedResponseButton to use `message.author` instead of removed `message.user`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689df1bb7da883258655d21aa69b0a33