### PR TITLE
Remove deprecated async roll option

### DIFF
--- a/module/foundry/documents/SR3ERoll.js
+++ b/module/foundry/documents/SR3ERoll.js
@@ -23,9 +23,15 @@ export default class SR3ERoll extends Roll {
 
    async evaluate(options = {}) {
       this.options = foundry.utils.mergeObject(this.options ?? {}, options ?? {});
-      await super.evaluate(this.options);
+      const evalOptions = { ...this.options };
+      delete evalOptions.async;
+      await super.evaluate(evalOptions);
 
-      DEBUG && LOG.inspect("Roll options passed in", [__FILE__, __LINE__, this.evaluate.name], options);
+      DEBUG && LOG.inspect(
+         "Roll options passed in",
+         [__FILE__, __LINE__, this.evaluate.name],
+         evalOptions
+      );
 
       const actor = this.actor || ChatMessage.getSpeakerActor(this.options.speaker);
 

--- a/module/services/OpposeRollService.js
+++ b/module/services/OpposeRollService.js
@@ -404,7 +404,7 @@ export default class OpposeRollService {
       if (!defender) throw new Error("sr3e: Defender not found");
 
       const roll = await Roll.fromData(rollData);
-      if (!roll._evaluated) await roll.evaluate({ async: true });
+      if (!roll._evaluated) await roll.evaluate();
 
       const tn = this.#computeTNFromPrep(prep); // ← use base+mods, not a baked number
       const successes = this.getSuccessCount({

--- a/module/svelte/apps/components/Editor.svelte
+++ b/module/svelte/apps/components/Editor.svelte
@@ -44,9 +44,7 @@
             editor()?.setContent(item.system.description);
         } else {
             editorContainer.innerHTML =
-                foundry.applications.ux.TextEditor.enrichHTML(textValue, {
-                    async: false,
-                });
+                foundry.applications.ux.TextEditor.enrichHTMLSync(textValue);
         }
 
         Log.success(

--- a/module/svelte/apps/components/JournalViewer.svelte
+++ b/module/svelte/apps/components/JournalViewer.svelte
@@ -30,7 +30,6 @@
         previewContent = await foundry.applications.ux.TextEditor.enrichHTML(
             content,
             {
-                async: true,
                 secrets: false,
                 documents: false,
             },

--- a/module/svelte/apps/components/Resistance.svelte
+++ b/module/svelte/apps/components/Resistance.svelte
@@ -39,19 +39,19 @@
             targetNumber: modifiedTargetNumber ?? prep.tn,
             explodes: true,
          }),
-         { actor },
-         {
-            type,
-            modifiers: modifiersArray,
-            targetNumber: modifiedTargetNumber ?? prep.tn,
-            attributeKey: attributeKeyForChat,
-            attributeName: attributeKeyForChat,
-            opposed: false,
-            isDefaulting,
-         }
+        { actor },
+        {
+           type,
+           modifiers: modifiersArray,
+           targetNumber: modifiedTargetNumber ?? prep.tn,
+           attributeKey: attributeKeyForChat,
+           attributeName: attributeKeyForChat,
+           opposed: false,
+           isDefaulting,
+        }
       );
 
-      await roll.evaluate({ async: true });
+      await roll.evaluate();
 
       // Send the composed roll to the resolver (runs on this client via your CONFIG.queries handler)
       await game.user.query("sr3e.resolveResistanceRoll", {


### PR DESCRIPTION
## Summary
- stop passing removed `async` flag to Roll#evaluate and related APIs
- replace synchronous text editing call with `enrichHTMLSync`
- update Svelte components and services to use new roll evaluation behavior

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Could not resolve "../../svelte/apps/metatypeApp.svelte")*


------
https://chatgpt.com/codex/tasks/task_e_689df3a4e25483258ef94a5b28f32acd