### PR TITLE
fix: stabilize recoil handling

### DIFF
--- a/module/svelte/apps/components/RollComposerComponent.svelte
+++ b/module/svelte/apps/components/RollComposerComponent.svelte
@@ -258,6 +258,7 @@
 
       const existing = modifiersArray[existingIndex];
       if (existing?.meta?.userTouched) return;
+      if (existing.value === row.value) return;
 
       const copy = [...modifiersArray];
       copy[existingIndex] = { ...existing, ...row, id: "recoil", weaponId: weapon.id, source: "auto" };
@@ -777,15 +778,9 @@
          const { shots } = recoilState(actor?.id);
          return shots > 0;
       })()}
-         {#if modifiersArray.some((m) => m.id === "recoil" || m.name === "Recoil")}
+        {#if modifiersArray.some((m) => m.id === "recoil" || m.name === "Recoil")}
             <div class="roll-composer-card">
-               <button
-                  class="regular"
-                  onclick={() => {
-                     modifiersArray = modifiersArray.filter((m) => m.id !== "recoil" && m.name !== "Recoil");
-                     clearAllRecoilForActor(actor?.id);
-                  }}
-               >
+               <button class="regular" onclick={ResetRecoil}>
                   Clear Recoil
                </button>
             </div>


### PR DESCRIPTION
## Summary
- prevent infinite recursion when recoil modifier appears
- wire "Clear Recoil" button to reset recoil counters and remove modifier

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Could not resolve "../../svelte/apps/metatypeApp.svelte" from "module/foundry/sheets/MetatypeItemSheet.js")*

------
https://chatgpt.com/codex/tasks/task_e_689df94b2ddc8325aec1d4cef9aec50a