### PR TITLE
refactor: route roll composer through procedures

### DIFF
--- a/module/services/procedure/FSM/AbstractProcedure.js
+++ b/module/services/procedure/FSM/AbstractProcedure.js
@@ -93,6 +93,9 @@ export default class AbstractProcedure {
 
   get linkedAttribute() { return get(this.#linkedAttributeStore); }
 
+  get caller() { return this.#caller; }
+  get item() { return this.#item; }
+
   set title(v) { this.#titleStore?.set?.(v); }
   get title()  { return this.#titleStore; } // store (Composer subscribes with {$title})
 


### PR DESCRIPTION
## Summary
- expose actor and item through `AbstractProcedure`
- add `FirearmProcedure` handling recoil, range, and precompute steps
- refactor `RollComposerComponent` to delegate combat logic to procedure classes

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689f32d7abb48325a30ceb92fd160058