### PR TITLE
Fix private field access in AbstractProcedure to prevent challenge failure

### DIFF
--- a/module/services/procedure/FSM/AbstractProcedure.js
+++ b/module/services/procedure/FSM/AbstractProcedure.js
@@ -55,10 +55,10 @@ export default class AbstractProcedure {
       if (!obj || typeof obj !== "object") throw new Error("fromJSON: invalid payload");
       const { schema = 1, kind, actor, item, state = {}, extra = null } = obj;
 
-      if (schema !== this.#SCHEMA_VERSION) {
+      if (schema !== AbstractProcedure.#SCHEMA_VERSION) {
          // schema bump handling goes here if needed
          DEBUG &&
-            LOG.warn(`AbstractProcedure.fromJSON: schema mismatch ${schema} != ${this.#SCHEMA_VERSION}`, [
+            LOG.warn(`AbstractProcedure.fromJSON: schema mismatch ${schema} != ${AbstractProcedure.#SCHEMA_VERSION}`, [
                __FILE__,
                __LINE__,
             ]);
@@ -279,7 +279,7 @@ export default class AbstractProcedure {
     */
    toJSON() {
       return {
-         schema: this.constructor.#SCHEMA_VERSION,
+         schema: AbstractProcedure.#SCHEMA_VERSION,
          kind: this.constructor.kind || this.constructor.name, // subclass should register a stable `kind`
          actor: {
             id: this.#caller?.id ?? null,


### PR DESCRIPTION
## Summary
- avoid private static field access through subclass in `fromJSON`
- reference static schema version directly in `toJSON`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Could not resolve ../../svelte/apps/metatypeApp.svelte)


------
https://chatgpt.com/codex/tasks/task_e_68a04dd0a5608325b0293a9556012104