### PR TITLE
Refactor initiator user handling for contested rolls

### DIFF
--- a/module/foundry/configure/configureQueries.js
+++ b/module/foundry/configure/configureQueries.js
@@ -34,14 +34,14 @@ export function configureQueries() {
   };
 
   /**
-   * Relay to the *initiator user* strictly, using the stored initiatorUserId on the contest.
+   * Relay to the *initiator user* strictly, using the stored initiator.userId on the contest.
    * No initiatorId param needed; we read from the local contest.
    */
   CONFIG.queries["sr3e.resolveOpposedRollRemote"] = async ({ contestId, rollData }) => {
     const contest = OpposeRollService.getContestById(contestId);
     if (!contest) return { ok: false, reason: "no contest" };
 
-    const initiatorUser = game.users.get(contest.initiatorUserId);
+    const initiatorUser = game.users.get(contest.initiator?.userId);
     if (!initiatorUser) return { ok: false, reason: "no initiator user" };
 
     if (initiatorUser.id === game.user.id) {


### PR DESCRIPTION
## Summary
- store initiator metadata as nested `{actorId, userId}` object
- resolve initiator user via new structure when forwarding opposed roll results

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Could not resolve "../../svelte/apps/metatypeApp.svelte")

------
https://chatgpt.com/codex/tasks/task_e_68a0f273de9c83259fcd64e2302d16c1