### PR TITLE
fix: guard against undefined actor in system recalculation

### DIFF
--- a/module/svelte/svelteHelpers/StoreManager.svelte.js
+++ b/module/svelte/svelteHelpers/StoreManager.svelte.js
@@ -124,11 +124,11 @@ export class StoreManager {
             store.set(v && typeof v === "object" ? (Array.isArray(v) ? [...v] : { ...v }) : v);
          };
 
-         const recalcHook = (actor) => {
-            if (actor.id !== this.#document.id) return;
-            const v = foundry.utils.getProperty(actor.system, dataPath);
-            store.set(v && typeof v === "object" ? (Array.isArray(v) ? [...v] : { ...v }) : v);
-         };
+        const recalcHook = (actor) => {
+           if (!actor || actor.id !== this.#document.id) return;
+           const v = foundry.utils.getProperty(actor.system, dataPath);
+           store.set(v && typeof v === "object" ? (Array.isArray(v) ? [...v] : { ...v }) : v);
+        };
 
          Hooks.on(`update${docType}`, updateHook);
          Hooks.on("actorSystemRecalculated", recalcHook);


### PR DESCRIPTION
## Summary
- avoid undefined actor access in read-only store recalculation hook

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: Could not resolve "../../svelte/apps/metatypeApp.svelte")

------
https://chatgpt.com/codex/tasks/task_e_68a0f5c8f2808325aa67a01acfba44f2