### PR TITLE
Refactor procedures to use execute method

### DIFF
--- a/module/svelte/apps/components/RollComposerComponent.svelte
+++ b/module/svelte/apps/components/RollComposerComponent.svelte
@@ -360,7 +360,7 @@
             class="regular"
             type="button"
             disabled={!primaryEnabled}
-            onclick={async () => await $procedureStore.challenge({ OnClose, CommitEffects })}
+            onclick={async () => await $procedureStore.execute({ OnClose, CommitEffects })}
          >
             {primaryLabel}
          </button>


### PR DESCRIPTION
## Summary
- remove shared challenge() from AbstractProcedure and add abstract execute()
- implement execute() in FirearmProcedure to handle attack rolls and contest expiration
- implement execute() in DodgeProcedure to deliver defense rolls
- update Roll Composer to invoke execute()

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a1a1e3202883259e34897d74220467