### PR TITLE
Include pool and karma dice in roll formula

### DIFF
--- a/module/svelte/apps/components/RollComposerComponent.svelte
+++ b/module/svelte/apps/components/RollComposerComponent.svelte
@@ -254,6 +254,18 @@
       displayCurrentDicePoolStore = actorStoreManager.GetSumROStore(`dicePools.${currentDicePoolName}`);
    });
 
+   $effect(() => {
+      const proc = $procedureStore;
+      if (!proc) return;
+      proc.poolDice = currentDicePoolAddition;
+   });
+
+   $effect(() => {
+      const proc = $procedureStore;
+      if (!proc) return;
+      proc.karmaDice = diceBought;
+   });
+
    function KarmaCostCalculator() {
       karmaCost = 0.5 * diceBought * (diceBought + 1);
    }


### PR DESCRIPTION
## Summary
- track pool and karma dice in AbstractProcedure and include them in formulas
- clamp selected pool dice and expose contributions in roll options
- update RollComposer component to forward chosen pool and karma dice

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Could not resolve module and other warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e4a6b1888325a6f9c422a5cdbee3