### PR TITLE
Ensure roll formulas use at least one die

### DIFF
--- a/module/services/procedure/FSM/AbstractProcedure.js
+++ b/module/services/procedure/FSM/AbstractProcedure.js
@@ -506,12 +506,12 @@ export default class AbstractProcedure {
    }
 
    buildFormula(explodes = true) {
-      const baseDice = Math.max(0, this.dice);
+      const baseDice = Math.max(0, Number(this.dice) || 0);
       const poolDice = this.#computeClampedPoolDice(this.poolDice);
-      const karmaDice = Math.max(0, this.karmaDice);
+      const karmaDice = Math.max(0, Number(this.karmaDice) || 0);
 
-      const totalDice = Math.max(0, baseDice + poolDice + karmaDice);
-      if (totalDice <= 0) return "0d6";
+      let totalDice = baseDice + poolDice + karmaDice;
+      totalDice = Number.isFinite(totalDice) ? Math.max(1, Math.floor(totalDice)) : 1;
 
       const base = `${totalDice}d6`;
       if (!explodes) return base;


### PR DESCRIPTION
## Summary
- guard against NaN or zero dice when building a roll formula

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Could not resolve "../../svelte/apps/metatypeApp.svelte" ...)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ead2279883258589dccfeeb24850