### PR TITLE
Ensure melee defense honors chosen basis

### DIFF
--- a/module/services/procedure/FSM/AbstractProcedure.js
+++ b/module/services/procedure/FSM/AbstractProcedure.js
@@ -165,7 +165,8 @@ export default class AbstractProcedure {
       return () => Hooks.off("targetToken", update);
    });
 
-   constructor(caller = null, item = null) {
+   constructor(caller = null, item = null, args = {}) {
+      this.args = args || {};
       if (this.constructor === AbstractProcedure) {
          DEBUG && LOG.error("Cannot instantiate abstract class AbstractProcedure", [__FILE__, __LINE__]);
          ui.notifications.warn("Cannot instantiate abstract class AbstractProcedure");
@@ -200,8 +201,12 @@ export default class AbstractProcedure {
          });
       }
 
-      if (caller && item) {
+      this.setBasis(this.args?.basis);
+
+      if (caller) {
          this.#caller = caller;
+      }
+      if (item) {
          this.#item = item;
 
          this.#titleStore.set(item.name);
@@ -492,6 +497,56 @@ export default class AbstractProcedure {
       const base = Number(get(this.#targetNumberStore) ?? 4);
       const sum = mods.reduce((a, m) => a + (Number(m?.value) || 0), base);
       return floor == null ? sum : Math.max(floor, sum);
+   }
+
+   setBasis(b = null) {
+      this.args = this.args || {};
+      this.args.basis = b || null;
+      if (b?.type === "attribute" && typeof b.key === "string") {
+         this.#linkedAttributeStore?.set?.(b.key);
+      }
+   }
+
+   getEffectiveDice({ includePool = false, includeKarma = false } = {}) {
+      const basis = this.args?.basis || {};
+      let baseDice = 0;
+
+      if (Number.isFinite(Number(basis.dice))) {
+         baseDice = Number(basis.dice);
+      } else if (basis.type === "skill") {
+         const skillId = basis.id || basis.skillId;
+         const skill = this.caller?.items?.get?.(skillId) || null;
+         if (skill) {
+            const type = skill.system?.skillType;
+            const sub = type ? skill.system?.[`${type}Skill`] ?? {} : {};
+            if (Number.isFinite(Number(basis.specIndex))) {
+               const specs = Array.isArray(sub.specializations) ? sub.specializations : [];
+               const spec = specs[Number(basis.specIndex)] || null;
+               baseDice = Number(spec?.value ?? 0) || 0;
+            } else {
+               baseDice = Number(sub.value ?? 0) || 0;
+            }
+         }
+      } else if (basis.type === "attribute") {
+         const key = String(basis.key || this.linkedAttribute || "strength");
+         const a = this.caller?.system?.attributes?.[key];
+         baseDice = Number(a?.total ?? a?.value ?? 0) || 0;
+      } else {
+         const key = String(this.linkedAttribute || "strength");
+         const a = this.caller?.system?.attributes?.[key];
+         baseDice = Number(a?.total ?? a?.value ?? 0) || 0;
+      }
+
+      baseDice = Math.max(0, Math.floor(Number(baseDice) || 0));
+
+      const poolDice = includePool
+         ? Math.max(0, Math.floor(this.#computeClampedPoolDice(this.poolDice)))
+         : 0;
+      const karmaDice = includeKarma
+         ? Math.max(0, Math.floor(Number(this.karmaDice) || 0))
+         : 0;
+
+      return { baseDice, poolDice, karmaDice, totalDice: baseDice + poolDice + karmaDice };
    }
 
    #computeClampedPoolDice(selected) {

--- a/module/services/procedure/FSM/MeleeFullDefenseProcedure.js
+++ b/module/services/procedure/FSM/MeleeFullDefenseProcedure.js
@@ -5,15 +5,10 @@ import ProcedureLock from "@services/procedure/FSM/ProcedureLock.js";
 
 export default class MeleeFullDefenseProcedure extends AbstractProcedure {
    constructor(defender, _item = null, args = {}) {
-      super(defender, _item);
-      this.args = args || {};
+      super(defender, _item, args);
 
-      // Seed base dice from chosen basis or fallback to Strength
-      const basis = this.args.basis || {};
-      const key = String(basis.key || "strength");
-      const a = defender?.system?.attributes?.[key];
-      const seed = Number(basis.dice ?? a?.total ?? a?.value ?? 0) || 0;
-      this.dice = Math.max(0, seed);
+      const { baseDice } = this.getEffectiveDice();
+      this.dice = baseDice;
 
       // Full Defense "owns" input while active
       ProcedureLock.assertEnter({
@@ -33,27 +28,13 @@ export default class MeleeFullDefenseProcedure extends AbstractProcedure {
       return game?.i18n?.localize?.("sr3e.button.fullDefend") ?? "Full Defense";
    }
 
-   // add below the class methods
    buildFormula(explodes = true) {
-      // 1) base dice from the active basis or fallback to Strength
-      const b = this.args?.basis || {};
-      const key = String(b.key || "strength");
-      const attr = this.caller?.system?.attributes?.[key];
-      const attrVal = Number(attr?.total ?? attr?.value ?? 0) || 0;
-
-      // prefer explicit basis.dice if composer supplied it; otherwise use attribute value
-      const baseDice = Math.max(0, Math.floor(Number(b.dice ?? this.dice ?? attrVal) || 0));
-
-      // 2) Full Defense initial test: no pool; karma is allowed as usual
-      const karmaDice = Math.max(0, Math.floor(Number(this.karmaDice) || 0));
-      const totalDice = baseDice + karmaDice;
-
+      const { totalDice } = this.getEffectiveDice({ includePool: false, includeKarma: true });
       if (!Number.isFinite(totalDice) || totalDice <= 0) return "0d6";
 
       const base = `${totalDice}d6`;
       if (!explodes) return base;
 
-      // Use the procedure’s final TN (your AbstractProcedure already clamps ≥2)
       const tn = Math.max(2, Number(this.finalTN()) || 2);
       return `${base}x${tn}`;
    }
@@ -64,25 +45,19 @@ export default class MeleeFullDefenseProcedure extends AbstractProcedure {
       // Initial Full Defense test: no Combat Pool on this roll
       this.poolDice = 0;
 
-      // If user reshaped UI and dice went to 0, re-seed from basis/attribute
-      if ((this.dice | 0) <= 0) {
-         const basis = this.args?.basis || {};
-         const key = String(basis.key || "strength");
-         const a = this.caller?.system?.attributes?.[key];
-         const seed = Number(basis.dice ?? a?.total ?? a?.value ?? 0) || 0;
-         this.dice = Math.max(0, seed);
-      }
-
       const actor = this.caller;
       const baseRoll = SR3ERoll.create(this.buildFormula(true), { actor });
 
-      // Reflect "no pool on this test" and keep attribute basis for transparency
       const basis = this.args?.basis || {};
       const opt = { ...(baseRoll.options || {}), pools: [] };
-      if (!opt.skill && !opt.skillKey && !opt.attribute && !opt.attributeKey) {
+      if (basis.type === "attribute") {
          opt.attributeKey = String(basis.key || "strength");
-         opt.isDefaulting = true;
+         opt.isDefaulting = basis.isDefaulting ?? true;
          if (Number.isFinite(basis.dice)) opt.attributeDice = Number(basis.dice);
+      } else if (basis.type === "skill") {
+         opt.skill = { id: basis.id, name: basis.name };
+         if (basis.specialization) opt.specialization = basis.specialization;
+         if (Number.isFinite(basis.dice)) opt.skillDice = Number(basis.dice);
       }
       baseRoll.options = opt;
 

--- a/module/services/procedure/FSM/MeleeStandardDefenseProcedure.js
+++ b/module/services/procedure/FSM/MeleeStandardDefenseProcedure.js
@@ -6,26 +6,21 @@ import ProcedureLock from "@services/procedure/FSM/ProcedureLock.js";
 export default class MeleeStandardDefenseProcedure extends AbstractProcedure {
    constructor(defender, _item = null, args = {}) {
       super(defender, _item, args);
+
+      const { baseDice } = this.getEffectiveDice();
+      this.dice = baseDice;
+
       ProcedureLock.assertEnter({
-         ownerKey: `${this.constructor.name}:${caller?.id}`,
+         ownerKey: `${this.constructor.name}:${this.caller?.id}`,
          priority: "advanced",
          onDenied: () => {},
       });
    }
 
-   // in MeleeStandardDefenseProcedure
    buildFormula(explodes = true) {
-      const b = this.args?.basis || {};
-      const key = String(b.key || "strength");
-      const attr = this.caller?.system?.attributes?.[key];
-      const attrVal = Number(attr?.total ?? attr?.value ?? 0) || 0;
-
-      const baseDice = Math.max(0, Math.floor(Number(b.dice ?? this.dice ?? attrVal) || 0));
-      const poolDice = Math.max(0, Math.floor(Number(this.poolDice) || 0));
-      const karmaDice = Math.max(0, Math.floor(Number(this.karmaDice) || 0));
-      const totalDice = baseDice + poolDice + karmaDice;
-
+      const { totalDice } = this.getEffectiveDice({ includePool: true, includeKarma: true });
       if (!Number.isFinite(totalDice) || totalDice <= 0) return "0d6";
+
       const base = `${totalDice}d6`;
       if (!explodes) return base;
 

--- a/module/svelte/apps/components/RollComposerComponent.svelte
+++ b/module/svelte/apps/components/RollComposerComponent.svelte
@@ -7,6 +7,7 @@
    import FirearmService from "@families/FirearmService.js";
    import AbstractProcedure from "@services/procedure/FSM/AbstractProcedure.js";
    import FirearmProcedure from "@services/procedure/FSM/FirearmProcedure.js";
+   import MeleeFullDefenseProcedure from "@services/procedure/FSM/MeleeFullDefenseProcedure.js";
    import { recoilState, clearAllRecoilForActor } from "@services/ComposerAttackController.js";
 
    let { actor, config } = $props();
@@ -142,6 +143,10 @@
       if (!(currentProcedure instanceof AbstractProcedure)) throw new Error("Unfit data type");
       clearStoreSubscriptions();
       $procedureStore = currentProcedure;
+
+      if (currentProcedure?.args?.basis) {
+         caller = { ...currentProcedure.args.basis };
+      }
 
       rangePrimedForWeaponId = null;
       rangeSuppressedForWeaponId = null;
@@ -420,7 +425,24 @@
             class="regular"
             type="button"
             disabled={!primaryEnabled}
-            onclick={async () => await $procedureStore.execute({ OnClose, CommitEffects })}
+            onclick={async () => {
+               const proc = $procedureStore;
+               if (!proc) return;
+               proc.setBasis?.(caller);
+               if (Number.isFinite(Number(caller?.dice))) proc.dice = Math.max(0, Number(caller.dice));
+               if (proc instanceof MeleeFullDefenseProcedure) proc.poolDice = 0;
+               const { totalDice } = proc.getEffectiveDice({
+                  includePool: !(proc instanceof MeleeFullDefenseProcedure),
+                  includeKarma: true,
+               });
+               if (!Number.isFinite(totalDice) || totalDice <= 0) {
+                  ui.notifications?.warn?.(
+                     localize("sr3e.warn.noDice") ?? "Cannot roll 0 dice."
+                  );
+                  return;
+               }
+               await proc.execute({ OnClose, CommitEffects });
+            }}
          >
             {primaryLabel}
          </button>


### PR DESCRIPTION
## Summary
- track procedure basis and compute effective dice in AbstractProcedure
- use new dice helper in melee defense procedures
- Roll Composer sets procedure basis/dice and blocks 0d6 submissions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Could not resolve "../../svelte/apps/metatypeApp.svelte")*

------
https://chatgpt.com/codex/tasks/task_e_68a780878f68832588df62e040536ffd