### PR TITLE
refactor: centralize procedure lock handling

### DIFF
--- a/module/services/procedure/FSM/FirearmProcedure.js
+++ b/module/services/procedure/FSM/FirearmProcedure.js
@@ -3,26 +3,15 @@ import SR3ERoll from "@documents/SR3ERoll.js";
 import OpposeRollService from "@services/OpposeRollService.js";
 import FirearmService from "@families/FirearmService.js";
 import { writable, get } from "svelte/store";
-import ProcedureLock from "@services/procedure/FSM/ProcedureLock.js";
 
 export default class FirearmProcedure extends AbstractProcedure {
    #attackCtx = null;
    #selectedPoolKey = null;
 
    constructor(caller, item) {
-      super(caller, item);
+      super(caller, item, { lockPriority: "advanced" });
       this.weaponModeStore = writable(item?.system?.mode ?? "semiauto");
       this.ammoAvailableStore = writable(this.#ammo());
-      ProcedureLock.assertEnter({
-         ownerKey: `${this.constructor.name}:${caller?.id}`,
-         priority: "advanced",
-         onDenied: () => {},
-      });
-   }
-
-   onDestroy() {
-      super.onDestroy?.();
-      ProcedureLock.release(`${this.constructor.name}:${this.caller?.id}`);
    }
 
    get tnModifiers() {

--- a/module/services/procedure/FSM/MeleeDefenseProcedure.js
+++ b/module/services/procedure/FSM/MeleeDefenseProcedure.js
@@ -1,13 +1,12 @@
 // module/services/procedure/FSM/MeleeDefenseProcedure.js
 import AbstractProcedure from "@services/procedure/FSM/AbstractProcedure.js";
 import SR3ERoll from "@documents/SR3ERoll.js";
-import ProcedureLock from "@services/procedure/FSM/ProcedureLock.js";
 
 function cap(s) { return typeof s === "string" && s ? s[0].toUpperCase() + s.slice(1) : s; }
 
 export default class MeleeDefenseProcedure extends AbstractProcedure {
   constructor(defender, _item = null, args = {}) {
-    super(defender, _item);
+    super(defender, _item, { lockPriority: "advanced" });
     this.args = args || {};
     this.mode = (this.args.mode === "full") ? "full" : "standard";   // "standard" | "full"
 
@@ -24,11 +23,6 @@ export default class MeleeDefenseProcedure extends AbstractProcedure {
       this.title = game?.i18n?.localize?.("sr3e.label.standardDefense") ?? "Standard Defense";
     }
 
-    ProcedureLock.assertEnter({
-      ownerKey: `${this.constructor.name}:${this.caller?.id}`,
-      priority: "advanced",
-      onDenied: () => {},
-    });
   }
 
   // Composer labels
@@ -91,8 +85,4 @@ export default class MeleeDefenseProcedure extends AbstractProcedure {
     return roll;
   }
 
-  onDestroy() {
-    super.onDestroy?.();
-    ProcedureLock.release(`${this.constructor.name}:${this.caller?.id}`);
-  }
 }

--- a/module/services/procedure/FSM/MeleeProcedure.js
+++ b/module/services/procedure/FSM/MeleeProcedure.js
@@ -4,7 +4,6 @@ import AbstractProcedure from "@services/procedure/FSM/AbstractProcedure";
 import SR3ERoll from "@documents/SR3ERoll.js";
 import OpposeRollService from "@services/OpposeRollService.js";
 import MeleeService from "@families/MeleeService.js";
-import ProcedureLock from "@services/procedure/FSM/ProcedureLock.js";
 import { StoreManager } from "@sveltehelpers/StoreManager.svelte.js";
 
 /**
@@ -17,17 +16,7 @@ export default class MeleeProcedure extends AbstractProcedure {
    #packet = null; // DamagePacket (snapshot)
 
    constructor(caller, item) {
-      super(caller, item);
-      ProcedureLock.assertEnter({
-         ownerKey: `${this.constructor.name}:${caller?.id}`,
-         priority: "advanced",
-         onDenied: () => {},
-      });
-   }
-
-   onDestroy() {
-      super.onDestroy?.();
-      ProcedureLock.release(`${this.constructor.name}:${this.caller?.id}`);
+      super(caller, item, { lockPriority: "advanced" });
    }
 
    // Minimal flavor used by SR3ERoll when needed

--- a/module/services/procedure/FSM/ResistanceProcedure.js
+++ b/module/services/procedure/FSM/ResistanceProcedure.js
@@ -10,7 +10,7 @@ export default class ResistanceProcedure extends AbstractProcedure {
    #defender;
 
    constructor(defender, _item = null, { prep } = {}) {
-      super(defender, _item); // base class won’t set #caller because item is null
+      super(defender, _item, { lockPriority: "advanced" }); // base class won’t set #caller because item is null
       this.#defender = defender; // keep our own pointer to the actor
       this.#prep = prep;
 


### PR DESCRIPTION
## Summary
- centralize ProcedureLock management in AbstractProcedure with automatic acquisition and release
- allow subclasses to define lock priority via constructor options
- remove duplicated lock code from procedure subclasses

## Testing
- `npm test` (fails: Missing script)
- `npm run build` (fails: Could not resolve "../../svelte/apps/metatypeApp.svelte")

------
https://chatgpt.com/codex/tasks/task_e_68a850f203d4832583a5ef82dcfed726