### PR TITLE
refactor: consolidate vanilla roll rendering

### DIFF
--- a/module/foundry/documents/SR3ERoll.js
+++ b/module/foundry/documents/SR3ERoll.js
@@ -81,7 +81,7 @@ export default class SR3ERoll extends Roll {
 
   async toMessageFromProcedure() {
     const descriptionHtml = String(this._procedure?.getChatDescription?.() ?? "");
-    const content = SR3ERoll.renderNonContested(this.toJSON(), { descriptionHtml });
+    const content = SR3ERoll.renderRollOutcome(this.toJSON(), { descriptionHtml });
     const flavor = String(this._procedure?.getFlavor?.() ?? "");
     return ChatMessage.create({
       content,

--- a/module/services/procedure/FSM/AbstractProcedure.js
+++ b/module/services/procedure/FSM/AbstractProcedure.js
@@ -662,8 +662,8 @@ export default class AbstractProcedure {
       const initName = initiator?.name ?? "Attacker";
       const tgtName = target?.name ?? "Defender";
 
-      const initHtml = SR3ERoll.renderVanilla(initiator, initiatorRoll);
-      const tgtHtml = SR3ERoll.renderVanilla(target, targetRoll);
+      const initHtml = SR3ERoll.renderRollOutcome(initiatorRoll);
+      const tgtHtml = SR3ERoll.renderRollOutcome(targetRoll);
       const winner = netSuccesses > 0 ? initName : tgtName;
 
       return {

--- a/module/services/procedure/FSM/FirearmProcedure.js
+++ b/module/services/procedure/FSM/FirearmProcedure.js
@@ -188,8 +188,8 @@ export default class FirearmProcedure extends AbstractProcedure {
       const headerBits = this.#attackHeader(exportCtx);
       const iSummary = this.#summarizeRollGeneric(initiator, initiatorRoll);
       const tSummary = this.#summarizeRollGeneric(target, targetRoll);
-      const iHtml = SR3ERoll.renderVanilla(initiator, initiatorRoll);
-      const tHtml = SR3ERoll.renderVanilla(target, targetRoll);
+      const iHtml = SR3ERoll.renderRollOutcome(initiatorRoll);
+      const tHtml = SR3ERoll.renderRollOutcome(targetRoll);
       const winner = netSuccesses > 0 ? initiator : target;
       const html = `
     ${top}


### PR DESCRIPTION
## Summary
- use `renderRollOutcome` for rendering single-party rolls
- update firearm and abstract procedures to render contested outcomes via `renderRollOutcome`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Could not resolve "../../svelte/apps/metatypeApp.svelte")*


------
https://chatgpt.com/codex/tasks/task_e_68ab3c6ef86c8325864043a774a2be17