### PR TITLE
feat: detail contested skill and attribute rolls

### DIFF
--- a/module/services/procedure/FSM/SkillProcedure.js
+++ b/module/services/procedure/FSM/SkillProcedure.js
@@ -114,6 +114,58 @@ export default class SkillProcedure extends AbstractProcedure {
     if (contestId) this.setContestIds([contestId]);
   }
 
+  #cap(s) {
+    if (!s) return "";
+    const t = String(s)
+      .replace(/[_\-]+/g, " ")
+      .trim();
+    return t.charAt(0).toUpperCase() + t.slice(1);
+  }
+
+  #summarizeRollGeneric(rollJson) {
+    const o = rollJson?.options || {};
+    const readName = (v) => {
+      if (v == null) return null;
+      if (typeof v === "string") return v;
+      if (typeof v === "object") return v.name ?? v.label ?? v.key ?? null;
+      return null;
+    };
+    const skillName = readName(o.skillKey ?? o.skill);
+    const specName = readName(o.specialization ?? o.spec ?? o.specKey ?? o.specializationName);
+    const attrName = readName(o.attributeKey ?? o.attribute);
+    const isDefault = !!(o.isDefaulting ?? o.defaulting);
+    const bits = [];
+    if (skillName) {
+      bits.push(`Skill: ${this.#cap(skillName)}`);
+      if (specName) bits.push(`Specialization: ${this.#cap(specName)}`);
+      if (isDefault) bits.push("Defaulting");
+    } else if (attrName) {
+      bits.push(`Attribute: ${this.#cap(attrName)}`);
+    }
+    return bits.length
+      ? `<p class="sr3e-roll-summary"><small>${bits.join(", ")}</small></p>`
+      : "";
+  }
+
+  async renderContestOutcome(exportCtx, { initiator, target, initiatorRoll, targetRoll, netSuccesses }) {
+    const initName = initiator?.name ?? "Attacker";
+    const tgtName = target?.name ?? "Defender";
+    const iHtml = SR3ERoll.renderRollOutcome(initiatorRoll);
+    const tHtml = SR3ERoll.renderRollOutcome(targetRoll);
+    const iSummary = this.#summarizeRollGeneric(initiatorRoll);
+    const tSummary = this.#summarizeRollGeneric(targetRoll);
+    const winner = netSuccesses > 0 ? initName : tgtName;
+    return {
+      html: `
+      <p><strong>Contested roll between ${initName} and ${tgtName}</strong></p>
+      <h4>${initName}</h4>${iSummary}${iHtml}
+      <h4>${tgtName}</h4>${tSummary}${tHtml}
+      <p><strong>${winner}</strong> wins the opposed roll (${Math.abs(netSuccesses)} net successes)</p>
+    `,
+      resistancePrep: null,
+    };
+  }
+
   toJSONExtra() { return { skillId: this.#skillId, specName: this.#specName, poolKey: this.#poolKey, skillName: this.#skillName }; }
   async fromJSONExtra(extra) {
     this.#skillId   = extra?.skillId   ?? this.#skillId;


### PR DESCRIPTION
## Summary
- show skill, specialization, or attribute summaries in contested SkillProcedure rolls
- show skill, specialization, or attribute summaries in contested AttributeProcedure rolls

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Could not resolve "../../svelte/apps/metatypeApp.svelte")

------
https://chatgpt.com/codex/tasks/task_e_68ab7922747883258fdec86158967c7c