### PR TITLE
Show skill details in contested item rolls

### DIFF
--- a/module/services/procedure/FSM/FirearmProcedure.js
+++ b/module/services/procedure/FSM/FirearmProcedure.js
@@ -361,7 +361,7 @@ export default class FirearmProcedure extends AbstractProcedure {
       return tail.length ? `<p class="sr3e-roll-summary"><small>${tail.join(" • ")}</small></p>` : "";
    }
 
-   #summarizeRollGeneric(_actor, rollJson) {
+   #summarizeRollGeneric(actor, rollJson) {
       const o = rollJson?.options || {};
       const readName = (v) => {
          if (v == null) return null;
@@ -369,10 +369,21 @@ export default class FirearmProcedure extends AbstractProcedure {
          if (typeof v === "object") return v.name ?? v.label ?? v.key ?? null;
          return null;
       };
-      const skillName = readName(o.skillKey ?? o.skill);
-      const specName = readName(o.specialization ?? o.spec ?? o.specKey ?? o.specializationName);
-      const attrName = readName(o.attributeKey ?? o.attribute);
-      const isDefault = !!(o.isDefaulting ?? o.defaulting);
+      let skillName = readName(o.skillKey ?? o.skill);
+      let specName = readName(o.specialization ?? o.spec ?? o.specKey ?? o.specializationName);
+      let attrName = readName(o.attributeKey ?? o.attribute);
+      let isDefault = !!(o.isDefaulting ?? o.defaulting);
+
+      // Fallback: attacker’s item may carry the skill/specialization/defaulting info
+      if (!skillName && !attrName && actor?.id === this.caller?.id) {
+         const info = this.#resolveItemSkillAndSpec();
+         if (info) {
+            skillName = info.skillName ?? skillName;
+            specName = info.specName ?? specName;
+            isDefault = info.isDefault ?? isDefault;
+         }
+      }
+
       const mainBits = [];
       if (skillName) {
          mainBits.push(`Skill: ${this.#cap(skillName)}`);


### PR DESCRIPTION
## Summary
- display skill, specialization, and defaulting info for firearm contested rolls
- add contested roll output for melee weapons with skill information

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ab7ca034ac832586427fef83cfd57e