### PR TITLE
refactor: centralize procedure localization via Config.sr3e

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -5,7 +5,32 @@
          "type": "Ammuntion Type",
          "rounds": "Rounds",
          "maxcapacity": "Max Capacity",
-         "class": "Weapon Class"
+         "class": "Weapon Class",
+         "empty": "— Unloaded / Empty —",
+         "requiredClass": "Required class"
+      },
+      "button": {
+         "attack": "Attack",
+         "challenge": "Challenge!",
+         "defend": "Defend",
+         "fullDefend": "Full Defense",
+         "roll": "Roll!",
+         "dodge": "Dodge!",
+         "fire": "Fire",
+         "resist": "Resist"
+      },
+      "label": {
+         "challenge": "Challenge",
+         "roll": "Roll",
+         "dodge": "Dodge"
+      },
+      "warn": {
+         "defaultNotAllowed": "Defaulting not allowed",
+         "defaultTN8": "Default target number is 8",
+         "procedureBusy": "Another procedure is in progress."
+      },
+      "error": {
+         "challengeFailed": "Challenge failed"
       },
       "attributes": {
          "attributes": "Attributes",

--- a/module/foundry/config.js
+++ b/module/foundry/config.js
@@ -6,6 +6,35 @@ sr3e.ammunition = {
    rounds: "sr3e.ammunition.rounds",
    maxcapacity: "sr3e.ammunition.maxcapacity",
    class: "sr3e.ammunition.class",
+   empty: "sr3e.ammunition.empty",
+   requiredClass: "sr3e.ammunition.requiredClass",
+};
+
+sr3e.button = {
+   attack: "sr3e.button.attack",
+   challenge: "sr3e.button.challenge",
+   defend: "sr3e.button.defend",
+   fullDefend: "sr3e.button.fullDefend",
+   roll: "sr3e.button.roll",
+   dodge: "sr3e.button.dodge",
+   fire: "sr3e.button.fire",
+   resist: "sr3e.button.resist",
+};
+
+sr3e.label = {
+   challenge: "sr3e.label.challenge",
+   roll: "sr3e.label.roll",
+   dodge: "sr3e.label.dodge",
+};
+
+sr3e.warn = {
+   defaultNotAllowed: "sr3e.warn.defaultNotAllowed",
+   defaultTN8: "sr3e.warn.defaultTN8",
+   procedureBusy: "sr3e.warn.procedureBusy",
+};
+
+sr3e.error = {
+   challengeFailed: "sr3e.error.challengeFailed",
 };
 
 sr3e.attributes = {

--- a/module/services/procedure/FSM/AbstractProcedure.js
+++ b/module/services/procedure/FSM/AbstractProcedure.js
@@ -3,9 +3,7 @@ import { writable, derived, get, readable } from "svelte/store";
 import { localize } from "@services/utilities.js";
 import SR3ERoll from "@documents/SR3ERoll.js";
 
-function C() {
-   return CONFIG?.sr3e || {};
-}
+const config = Config.sr3e;
 
 export default class AbstractProcedure {
    // ---------- static: serialization registry & helpers ----------
@@ -187,7 +185,7 @@ export default class AbstractProcedure {
          this.#difficultyStore = derived(this.#targetNumberStore, (tn) => {
             if (tn == null) return "";
             const n = Number(tn);
-            const d = C().difficulty || {};
+            const d = config.difficulty || {};
             if (n === 2) return d.simple || "";
             if (n === 3) return d.routine || "";
             if (n === 4) return d.average || "";
@@ -256,7 +254,7 @@ export default class AbstractProcedure {
          const unsubPenalty = penaltyStore.subscribe((p) => {
             const v = Number(p ?? 0);
             this._removeModById("penalty");
-            if (v > 0) this.upsertMod({ id: "penalty", name: localize(C().health?.penalty), value: -v });
+            if (v > 0) this.upsertMod({ id: "penalty", name: localize(config.health?.penalty), value: -v });
          });
          this.#disposers.push(unsubPenalty);
       }
@@ -409,7 +407,7 @@ export default class AbstractProcedure {
    // The default label; subclasses override as they like.
    getKindOfRollLabel() {
       const t = game?.i18n?.localize?.bind(game.i18n);
-      return this.hasTargets ? t?.("sr3e.label.challenge") ?? "Challenge" : t?.("sr3e.label.roll") ?? "Roll";
+      return this.hasTargets ? t?.(config.label.challenge) ?? "Challenge" : t?.(config.label.roll) ?? "Roll";
    }
 
    getItemLabel() {
@@ -420,7 +418,7 @@ export default class AbstractProcedure {
    // (keep these from earlier)
    getPrimaryActionLabel() {
       const t = game?.i18n?.localize?.bind(game.i18n);
-      return this.hasTargets ? t?.("sr3e.button.challenge") ?? "Challenge!" : t?.("sr3e.button.roll") ?? "Roll!";
+      return this.hasTargets ? t?.(config.button.challenge) ?? "Challenge!" : t?.(config.button.roll) ?? "Roll!";
    }
 
    isPrimaryActionEnabled() {
@@ -597,7 +595,7 @@ export default class AbstractProcedure {
       const prettyPool = (k) => {
          if (!k) return "Pool";
          // Try config label first, then prettify the key
-         const label = CONFIG?.sr3e?.dicepools?.[k];
+         const label = config.dicepools?.[k];
          if (label) return typeof game?.i18n?.localize === "function" ? game.i18n.localize(label) : String(label);
          return String(k)
             .replace(/([A-Z])/g, " $1")
@@ -744,12 +742,12 @@ export default class AbstractProcedure {
    #assertDefaultAllowed() {
       if (this.#item?.system?.noDefault) {
          DEBUG && LOG.warn("Defaulting not allowed for this test", [__FILE__, __LINE__]);
-         ui.notifications.warn(localize("sr3e.warn.defaultNotAllowed"));
+         ui.notifications.warn(localize(config.warn.defaultNotAllowed));
          return false;
       }
       if (this.#preDefaultTN() >= 8) {
          DEBUG && LOG.warn("Defaulting disallowed at TN ≥ 8 before defaulting", [__FILE__, __LINE__]);
-         ui.notifications.warn(localize("sr3e.warn.defaultTN8"));
+         ui.notifications.warn(localize(config.warn.defaultTN8));
          return false;
       }
       return true;

--- a/module/services/procedure/FSM/DodgeProcedure.js
+++ b/module/services/procedure/FSM/DodgeProcedure.js
@@ -3,6 +3,8 @@ import AbstractProcedure from "@services/procedure/FSM/AbstractProcedure";
 import SR3ERoll from "@documents/SR3ERoll.js";
 import OpposeRollService from "@services/OpposeRollService.js";
 
+const config = Config.sr3e;
+
 export default class DodgeProcedure extends AbstractProcedure {
    static kind = "dodge";
 
@@ -11,7 +13,7 @@ export default class DodgeProcedure extends AbstractProcedure {
    constructor(defender, _noItem = null, { contestId } = {}) {
       super(defender, null);
 
-      this.title = game?.i18n?.localize?.("sr3e.dodge.title") ?? "Dodge";
+      this.title = game?.i18n?.localize?.(config.dodge.dodge) ?? "Dodge";
       this.#contestId = contestId ?? null;
 
       // Base TN 4
@@ -23,13 +25,13 @@ export default class DodgeProcedure extends AbstractProcedure {
 
    // Flavor in the composer
    getKindOfRollLabel() {
-      return game?.i18n?.localize?.("sr3e.label.dodge") ?? "Dodge";
+      return game?.i18n?.localize?.(config.label.dodge) ?? "Dodge";
    }
    getItemLabel() {
       return typeof this.title === "string" ? this.title : "";
    }
    getPrimaryActionLabel() {
-      return game?.i18n?.localize?.("sr3e.button.dodge") ?? "Dodge!";
+      return game?.i18n?.localize?.(config.button.dodge) ?? "Dodge!";
    }
 
    // Never start a new opposed flow from here
@@ -71,7 +73,7 @@ export default class DodgeProcedure extends AbstractProcedure {
          return roll;
       } catch (err) {
          DEBUG && LOG.error("Challenge flow failed", [__FILE__, __LINE__, err]);
-         ui.notifications.error(game.i18n.localize?.("sr3e.error.challengeFailed") ?? "Challenge failed");
+         ui.notifications.error(game.i18n.localize?.(config.error.challengeFailed) ?? "Challenge failed");
          throw err;
       }
    }

--- a/module/services/procedure/FSM/FirearmProcedure.js
+++ b/module/services/procedure/FSM/FirearmProcedure.js
@@ -5,6 +5,8 @@ import FirearmService from "@families/FirearmService.js";
 import { writable, get } from "svelte/store";
 import ProcedureLock from "@services/procedure/FSM/ProcedureLock.js";
 
+const config = Config.sr3e;
+
 export default class FirearmProcedure extends AbstractProcedure {
    #attackCtx = null;
    #selectedPoolKey = null;
@@ -108,15 +110,15 @@ export default class FirearmProcedure extends AbstractProcedure {
          await this.onChallengeResolved?.({ roll, actor });
          return roll;
       } catch (err) {
-         ui.notifications.error(game.i18n.localize?.("sr3e.error.challengeFailed") ?? "Challenge failed");
+         ui.notifications.error(game.i18n.localize?.(config.error.challengeFailed) ?? "Challenge failed");
          throw err;
       }
    }
 
    getPrimaryActionLabel() {
       const t = game?.i18n?.localize?.bind(game.i18n);
-      if (this.hasTargets) return t?.("sr3e.button.challenge") ?? "Challenge!";
-      const fire = t?.("sr3e.button.fire") ?? "Fire";
+      if (this.hasTargets) return t?.(config.button.challenge) ?? "Challenge!";
+      const fire = t?.(config.button.fire) ?? "Fire";
       const weapon = this.item?.name ?? "";
       return weapon ? `${fire} ${weapon}` : fire;
    }

--- a/module/services/procedure/FSM/MeleeFullDefenseProcedure.js
+++ b/module/services/procedure/FSM/MeleeFullDefenseProcedure.js
@@ -3,6 +3,8 @@ import AbstractProcedure from "@services/procedure/FSM/AbstractProcedure";
 import SR3ERoll from "@documents/SR3ERoll.js";
 import ProcedureLock from "@services/procedure/FSM/ProcedureLock.js";
 
+const config = Config.sr3e;
+
 /**
  * Full Defense (Parry): skill only, NO Combat Pool.
  * We hard-zero any pool contribution at roll time to enforce it.
@@ -29,7 +31,7 @@ export default class MeleeFullDefenseProcedure extends AbstractProcedure {
       return `<div>Melee Defense (Full)</div>`;
    }
    getPrimaryActionLabel() {
-      return game?.i18n?.localize?.("sr3e.button.fullDefend") ?? "Full Defense";
+      return game?.i18n?.localize?.(config.button.fullDefend) ?? "Full Defense";
    }
 
    async execute({ OnClose } = {}) {

--- a/module/services/procedure/FSM/MeleeProcedure.js
+++ b/module/services/procedure/FSM/MeleeProcedure.js
@@ -6,6 +6,8 @@ import OpposeRollService from "@services/OpposeRollService.js";
 import MeleeService from "@families/MeleeService.js";
 import ProcedureLock from "@services/procedure/FSM/ProcedureLock.js";
 
+const config = Config.sr3e;
+
 /**
  * Attacker procedure for melee.
  * - Builds a simple TN (base 4 + composer mods)
@@ -42,8 +44,8 @@ export default class MeleeProcedure extends AbstractProcedure {
    // Primary button label
    getPrimaryActionLabel() {
       const t = game?.i18n?.localize?.bind(game.i18n);
-      if (this.hasTargets) return t?.("sr3e.button.challenge") ?? "Challenge!";
-      const atk = t?.("sr3e.button.attack") ?? "Attack";
+      if (this.hasTargets) return t?.(config.button.challenge) ?? "Challenge!";
+      const atk = t?.(config.button.attack) ?? "Attack";
       const weapon = this.item?.name ?? "";
       return weapon ? `${atk} ${weapon}` : atk;
    }
@@ -91,7 +93,7 @@ export default class MeleeProcedure extends AbstractProcedure {
          return roll;
       } catch (err) {
          DEBUG && LOG.error("Melee challenge flow failed", [__FILE__, __LINE__, err]);
-         ui.notifications.error(game.i18n.localize?.("sr3e.error.challengeFailed") ?? "Challenge failed");
+         ui.notifications.error(game.i18n.localize?.(config.error.challengeFailed) ?? "Challenge failed");
          throw err;
       }
    }

--- a/module/services/procedure/FSM/MeleeStandardDefenseProcedure.js
+++ b/module/services/procedure/FSM/MeleeStandardDefenseProcedure.js
@@ -3,6 +3,8 @@ import AbstractProcedure from "@services/procedure/FSM/AbstractProcedure";
 import SR3ERoll from "@documents/SR3ERoll.js";
 import ProcedureLock from "@services/procedure/FSM/ProcedureLock.js";
 
+const config = Config.sr3e;
+
 export default class MeleeStandardDefenseProcedure extends AbstractProcedure {
    constructor(defender, _item = null, args = {}) {
       super(defender, _item, args);
@@ -25,7 +27,7 @@ export default class MeleeStandardDefenseProcedure extends AbstractProcedure {
       return `<div>Melee Defense (Standard)</div>`;
    }
    getPrimaryActionLabel() {
-      return game?.i18n?.localize?.("sr3e.button.defend") ?? "Defend";
+      return game?.i18n?.localize?.(config.button.defend) ?? "Defend";
    }
 
    // No pool limitations; defender can add their chosen Combat Pool

--- a/module/services/procedure/FSM/ResistanceProcedure.js
+++ b/module/services/procedure/FSM/ResistanceProcedure.js
@@ -5,6 +5,8 @@ import SR3ERoll from "@documents/SR3ERoll.js";
 import OpposeRollService from "@services/OpposeRollService.js";
 import ResistanceEngine from "@rules/ResistanceEngine.js";
 
+const config = Config.sr3e;
+
 export default class ResistanceProcedure extends AbstractProcedure {
    #prep;
    #defender;
@@ -52,7 +54,7 @@ export default class ResistanceProcedure extends AbstractProcedure {
       return 1;
    }
    getCaller() {
-      return { type: "attribute", key: "body", name: "Body" };
+      return { type: "attribute", key: "body", name: game.i18n.localize(config.attributes.body) };
    }
 
    getFlavor() {
@@ -65,7 +67,7 @@ export default class ResistanceProcedure extends AbstractProcedure {
    async onChallengeWillRoll({ baseRoll, actor }) {
       await super.onChallengeWillRoll?.({ baseRoll, actor });
       baseRoll.options = baseRoll.options || {};
-      baseRoll.options.attribute = { key: "body", name: "Body" };
+      baseRoll.options.attribute = { key: "body", name: game.i18n.localize(config.attributes.body) };
 
       const tnBase = Number(get(this.targetNumberStore));
       const tnMods = (get(this.modifiersArrayStore) || []).map((m) => ({
@@ -80,7 +82,7 @@ export default class ResistanceProcedure extends AbstractProcedure {
 
    getPrimaryActionLabel() {
       const t = game?.i18n?.localize?.bind(game.i18n);
-      return t?.("sr3e.button.resist") ?? "Resist";
+      return t?.(config.button.resist) ?? "Resist";
    }
 
    finalTN({ floor = 2 } = {}) {

--- a/module/services/procedure/FSM/UncontestedAttributeProcedure.js
+++ b/module/services/procedure/FSM/UncontestedAttributeProcedure.js
@@ -4,6 +4,8 @@ import AbstractProcedure from "@services/procedure/FSM/AbstractProcedure.js";
 import ProcedureLock from "@services/procedure/FSM/ProcedureLock.js";
 import SR3ERoll from "@documents/SR3ERoll.js";
 
+const config = Config.sr3e;
+
 export default class UncontestedAttributeProcedure extends AbstractProcedure {
   static KIND = "uncontested-attribute";
   static register() { AbstractProcedure.registerSubclass(this.KIND, this); }
@@ -16,7 +18,7 @@ export default class UncontestedAttributeProcedure extends AbstractProcedure {
     this.#attrKey = String(attributeKey || "strength").toLowerCase();
 
     // set title + base dice from attribute
-    const label = title || (CONFIG?.sr3e?.attributes?.[this.#attrKey] ?? this.#attrKey);
+    const label = title || (config?.attributes?.[this.#attrKey] ?? this.#attrKey);
     this.title = typeof label === "string" ? label : this.#attrKey;
 
     const a = caller?.system?.attributes?.[this.#attrKey];
@@ -37,7 +39,7 @@ export default class UncontestedAttributeProcedure extends AbstractProcedure {
     const ok = ProcedureLock.assertEnter({
       ownerKey: `${UncontestedAttributeProcedure.KIND}:${this.caller?.id}`,
       priority: "simple",
-      onDenied: () => ui.notifications.warn(game.i18n.localize?.("sr3e.warn.procedureBusy") ?? "Another procedure is in progress.")
+      onDenied: () => ui.notifications.warn(game.i18n.localize?.(config.warn.procedureBusy) ?? "Another procedure is in progress.")
     });
     if (!ok) return null;
 

--- a/module/services/procedure/FSM/UncontestedSkillProcedure.js
+++ b/module/services/procedure/FSM/UncontestedSkillProcedure.js
@@ -3,6 +3,8 @@ import AbstractProcedure from "@services/procedure/FSM/AbstractProcedure.js";
 import ProcedureLock from "@services/procedure/FSM/ProcedureLock.js";
 import SR3ERoll from "@documents/SR3ERoll.js";
 
+const config = Config.sr3e;
+
 export default class UncontestedSkillProcedure extends AbstractProcedure {
   static KIND = "uncontested-skill";
   static register() { AbstractProcedure.registerSubclass(this.KIND, this); }
@@ -51,7 +53,7 @@ export default class UncontestedSkillProcedure extends AbstractProcedure {
     const ok = ProcedureLock.assertEnter({
       ownerKey: `${UncontestedSkillProcedure.KIND}:${this.caller?.id}`,
       priority: "simple",
-      onDenied: () => ui.notifications.warn(game.i18n.localize?.("sr3e.warn.procedureBusy") ?? "Another procedure is in progress.")
+      onDenied: () => ui.notifications.warn(game.i18n.localize?.(config.warn.procedureBusy) ?? "Another procedure is in progress.")
     });
     if (!ok) return null;
 

--- a/module/services/procedure/families/FirearmService.js
+++ b/module/services/procedure/families/FirearmService.js
@@ -10,8 +10,8 @@ import RangeService, { tnDeltaFromShort } from "@rules/RangeService.js";
 export default class FirearmService {
    // ——— mode helpers ———
    static #weaponModes() {
-      const m = CONFIG?.sr3e?.weaponMode;
-      if (!m || typeof m !== "object") throw new Error("sr3e: CONFIG.sr3e.weaponMode missing");
+      const m = Config?.sr3e?.weaponMode;
+      if (!m || typeof m !== "object") throw new Error("sr3e: Config.sr3e.weaponMode missing");
       return Object.keys(m);
    }
    static #modeKey(w) {

--- a/module/services/procedure/game/AmmoService.js
+++ b/module/services/procedure/game/AmmoService.js
@@ -1,3 +1,5 @@
+const config = Config.sr3e;
+
 export default class AmmoService {
   static getAttachedAmmo(actor, weapon) {
     DEBUG && LOG.info("", [__FILE__, __LINE__, AmmoService.getAttachedAmmo.name]);
@@ -82,9 +84,9 @@ export default class AmmoService {
   // inlined here to keep @game self-contained
   static async pickAmmoDialog(ammoItems, weapon, { needClass = "", allowEmpty = false } = {}) {
     DEBUG && LOG.info("", [__FILE__, __LINE__, AmmoService.pickAmmoDialog.name]);
-    const emptyLabel = game.i18n.localize("sr3e.ammunition.empty") || "— Unloaded / Empty —";
-    const roundsKey = game.i18n.localize("sr3e.ammunition.rounds") || "rounds";
-    const ammoKey = game.i18n.localize("sr3e.ammunition.ammunition") || "Ammunition";
+    const emptyLabel = game.i18n.localize(config.ammunition.empty) || "— Unloaded / Empty —";
+    const roundsKey = game.i18n.localize(config.ammunition.rounds) || "rounds";
+    const ammoKey = game.i18n.localize(config.ammunition.ammunition) || "Ammunition";
 
     const options = [];
     if (allowEmpty) options.push(`<option value="__EMPTY__">${emptyLabel}</option>`);
@@ -96,7 +98,7 @@ export default class AmmoService {
     }
 
     const needClassHint = needClass
-      ? `<p class="notes"><small>${game.i18n.localize("sr3e.ammunition.requiredClass") || "Required class"}: <b>${needClass}</b></small></p>`
+      ? `<p class="notes"><small>${game.i18n.localize(config.ammunition.requiredClass) || "Required class"}: <b>${needClass}</b></small></p>`
       : "";
 
     const content = `
@@ -110,14 +112,14 @@ export default class AmmoService {
       window: { title: `Reload ${weapon.name}` },
       content,
       ok: {
-        label: game.i18n.localize("sr3e.modal.confirm") || "OK",
+        label: game.i18n.localize(config.modal.confirm) || "OK",
         callback: (event, button, dialog) => {
           const id = dialog.element.querySelector('select[name="ammoId"]').value;
           if (id === "__EMPTY__") return "__EMPTY__";
           return ammoItems.find((i) => i.id === id);
         },
       },
-      cancel: { label: game.i18n.localize("sr3e.modal.decline") || "Cancel" },
+      cancel: { label: game.i18n.localize(config.modal.decline) || "Cancel" },
       rejectClose: false,
       modal: true,
     });

--- a/module/svelte/apps/components/RollComposerComponent.svelte
+++ b/module/svelte/apps/components/RollComposerComponent.svelte
@@ -9,7 +9,7 @@
    import FirearmProcedure from "@services/procedure/FSM/FirearmProcedure.js";
    import { recoilState, clearAllRecoilForActor } from "@services/ComposerAttackController.js";
 
-   let { actor, config } = $props();
+   let { actor, config = Config.sr3e } = $props();
 
    let actorStoreManager = StoreManager.Subscribe(actor);
    onDestroy(() => {


### PR DESCRIPTION
## Summary
- use `Config.sr3e` tokens for all procedure labels, buttons and warnings
- add missing localization tokens and defaults in config and en.json
- default RollComposer component config to `Config.sr3e`

## Testing
- `npm run build` *(fails: Could not resolve "../../svelte/apps/metatypeApp.svelte" from "module/foundry/sheets/MetatypeItemSheet.js")*


------
https://chatgpt.com/codex/tasks/task_e_68ac0389e7f483258243477e33d4416a