### PR TITLE
refactor: use runtime config getter

### DIFF
--- a/module/services/procedure/FSM/AbstractProcedure.js
+++ b/module/services/procedure/FSM/AbstractProcedure.js
@@ -4,7 +4,9 @@ import { localize } from "@services/utilities.js";
 import SR3ERoll from "@documents/SR3ERoll.js";
 import ProcedureLock from "@services/procedure/FSM/ProcedureLock.js";
 
-const config = CONFIG.sr3e;
+function RuntimeConfig() {
+   return CONFIG?.sr3e || {};
+}
 
 export default class AbstractProcedure {
    // ---------- static: serialization registry & helpers ----------
@@ -194,7 +196,7 @@ export default class AbstractProcedure {
          this.#difficultyStore = derived(this.#targetNumberStore, (tn) => {
             if (tn == null) return "";
             const n = Number(tn);
-            const d = localize(config.procedure.difficulty) || {};
+           const d = localize(RuntimeConfig().procedure.difficulty) || {};
             if (n === 2) return d.simple || "";
             if (n === 3) return d.routine || "";
             if (n === 4) return d.average || "";
@@ -275,7 +277,7 @@ export default class AbstractProcedure {
          const unsubPenalty = penaltyStore.subscribe((p) => {
             const v = Number(p ?? 0);
             this._removeModById("penalty");
-            if (v > 0) this.upsertMod({ id: "penalty", name: localize(config.health.penalty), value: -v });
+            if (v > 0) this.upsertMod({ id: "penalty", name: localize(RuntimeConfig().health.penalty), value: -v });
          });
          this.#disposers.push(unsubPenalty);
       }
@@ -435,8 +437,8 @@ export default class AbstractProcedure {
    // The default label; subclasses override as they like.
    getKindOfRollLabel() {
       return this.hasTargets
-         ? localize(config.procedure.challenge) ?? "Challenge"
-         : localize(config.procedure.roll) ?? "Roll";
+         ? localize(RuntimeConfig().procedure.challenge) ?? "Challenge"
+         : localize(RuntimeConfig().procedure.roll) ?? "Roll";
    }
 
    getItemLabel() {
@@ -447,8 +449,8 @@ export default class AbstractProcedure {
    // (keep these from earlier)
    getPrimaryActionLabel() {
       return this.hasTargets
-         ? localize(config.procedure.challenge) ?? "Challenge!"
-         : t?.(config.procedure.roll) ?? "Roll!";
+         ? localize(RuntimeConfig().procedure.challenge) ?? "Challenge!"
+         : t?.(RuntimeConfig().procedure.roll) ?? "Roll!";
    }
 
    isPrimaryActionEnabled() {

--- a/module/services/procedure/FSM/AttributeProcedure.js
+++ b/module/services/procedure/FSM/AttributeProcedure.js
@@ -4,7 +4,9 @@ import SR3ERoll from "@documents/SR3ERoll.js";
 import { get } from "svelte/store";
 import { localize } from "@services/utilities.js";
 
-const config = CONFIG.sr3e;
+function RuntimeConfig() {
+   return CONFIG?.sr3e || {};
+}
 
 export default class AttributeProcedure extends AbstractProcedure {
    static KIND = "attribute";

--- a/module/services/procedure/FSM/DodgeProcedure.js
+++ b/module/services/procedure/FSM/DodgeProcedure.js
@@ -4,7 +4,9 @@ import SR3ERoll from "@documents/SR3ERoll.js";
 import OpposeRollService from "@services/OpposeRollService.js";
 import { localize } from "@services/utilities.js";
 
-const config = CONFIG.sr3e;
+function RuntimeConfig() {
+   return CONFIG?.sr3e || {};
+}
 
 export default class DodgeProcedure extends AbstractProcedure {
    static kind = "dodge";
@@ -14,7 +16,7 @@ export default class DodgeProcedure extends AbstractProcedure {
    constructor(defender, _noItem = null, { contestId } = {}) {
       super(defender, null);
 
-      this.title = localize(config.procedure.dodgetitle);
+      this.title = localize(RuntimeConfig().procedure.dodgetitle);
       this.#contestId = contestId ?? null;
 
       // Base TN 4
@@ -23,13 +25,13 @@ export default class DodgeProcedure extends AbstractProcedure {
 
    // Flavor in the composer
    getKindOfRollLabel() {
-      return localize(config.procedure.dodge);
+      return localize(RuntimeConfig().procedure.dodge);
    }
    getItemLabel() {
       return typeof this.title === "string" ? this.title : "";
    }
    getPrimaryActionLabel() {
-      return localize(config.procedure.dodgebutton);
+      return localize(RuntimeConfig().procedure.dodgebutton);
    }
 
    // Never start a new opposed flow from here
@@ -42,7 +44,7 @@ export default class DodgeProcedure extends AbstractProcedure {
    }
 
    getChatDescription() {
-      return localize(config.procedure.dodgedescription);
+      return localize(RuntimeConfig().procedure.dodgedescription);
    }
 
    async execute({ OnClose, CommitEffects } = {}) {

--- a/module/services/procedure/FSM/ExplosiveProcedure.js
+++ b/module/services/procedure/FSM/ExplosiveProcedure.js
@@ -1,7 +1,9 @@
 import AbstractProcedure from "@services/procedure/FSM/AbstractProcedure";
 import { localize } from "@services/utilities.js";
 
-const config = CONFIG.sr3e;
+function RuntimeConfig() {
+   return CONFIG?.sr3e || {};
+}
 
 
 

--- a/module/services/procedure/FSM/FirearmProcedure.js
+++ b/module/services/procedure/FSM/FirearmProcedure.js
@@ -5,7 +5,9 @@ import FirearmService from "@families/FirearmService.js";
 import { writable, get } from "svelte/store";
 import { localize } from "@services/utilities.js";
 
-const config = CONFIG.sr3e;
+function RuntimeConfig() {
+   return CONFIG?.sr3e || {};
+}
 
 export default class FirearmProcedure extends AbstractProcedure {
    #attackCtx = null;
@@ -106,14 +108,14 @@ export default class FirearmProcedure extends AbstractProcedure {
    }
 
    getPrimaryActionLabel() {
-      if (this.hasTargets) return localize(config.procedure.challenge);
-      const fire = localize(config.procedure.fire);
+      if (this.hasTargets) return localize(RuntimeConfig().procedure.challenge);
+      const fire = localize(RuntimeConfig().procedure.fire);
       const weapon = this.item?.name ?? "";
       return weapon ? `${fire} ${weapon}` : fire;
    }
 
    getKindOfRollLabel() {
-      return this.hasTargets ? localize(config.procedure.challenge) : localize(config.procedure.roll);
+      return this.hasTargets ? localize(RuntimeConfig().procedure.challenge) : localize(RuntimeConfig().procedure.roll);
    }
 
    getItemLabel() {
@@ -144,7 +146,7 @@ export default class FirearmProcedure extends AbstractProcedure {
          type: "attribute",
          key: "reaction",
          tnMod: 0,
-         tnLabel: localize(config.procedure.weapondifficulty),
+         tnLabel: localize(RuntimeConfig().procedure.weapondifficulty),
       };
    }
 

--- a/module/services/procedure/FSM/MeleeDefenseProcedure.js
+++ b/module/services/procedure/FSM/MeleeDefenseProcedure.js
@@ -3,7 +3,9 @@ import AbstractProcedure from "@services/procedure/FSM/AbstractProcedure.js";
 import SR3ERoll from "@documents/SR3ERoll.js";
 import { localize } from "@services/utilities.js";
 
-const config = CONFIG.sr3e;
+function RuntimeConfig() {
+   return CONFIG?.sr3e || {};
+}
 
 function cap(s) { return typeof s === "string" && s ? s[0].toUpperCase() + s.slice(1) : s; }
 
@@ -19,26 +21,26 @@ export default class MeleeDefenseProcedure extends AbstractProcedure {
 
     // Panel title
     if (this.mode === "full") {
-      const parry = localize(config.procedure.parry);
+      const parry = localize(RuntimeConfig().procedure.parry);
       this.title = b?.type === "attribute"
         ? `${parry} (${cap(b.key)})`
         : `${parry} (${b?.name})`;
     } else {
-      this.title = localize(config.procedure.standardDefense);
+      this.title = localize(RuntimeConfig().procedure.standardDefense);
     }
   }
 
   // Composer labels
   getKindOfRollLabel() {
     return this.mode === "full"
-      ? localize(config.procedure.fullDefense)
-      : localize(config.procedure.standardDefense);
+      ? localize(RuntimeConfig().procedure.fullDefense)
+      : localize(RuntimeConfig().procedure.standardDefense);
   }
 
   getPrimaryActionLabel() {
     return this.mode === "full"
-      ? localize(config.procedure.fullDefend)
-      : localize(config.procedure.defend);
+      ? localize(RuntimeConfig().procedure.fullDefend)
+      : localize(RuntimeConfig().procedure.defend);
   }
 
   getFlavor() { return String(this.title); }

--- a/module/services/procedure/FSM/MeleeProcedure.js
+++ b/module/services/procedure/FSM/MeleeProcedure.js
@@ -7,7 +7,9 @@ import MeleeService from "@families/MeleeService.js";
 import { StoreManager } from "@sveltehelpers/StoreManager.svelte.js";
 import { localize } from "@services/utilities.js";
 
-const config = CONFIG.sr3e;
+function RuntimeConfig() {
+   return CONFIG?.sr3e || {};
+}
 
 /**
  * Attacker procedure for melee.
@@ -34,8 +36,8 @@ export default class MeleeProcedure extends AbstractProcedure {
 
    // Primary button label
    getPrimaryActionLabel() {
-      if (this.hasTargets) return localize(config.procedure.challenge);
-      const atk = localize(config.procedure.attack);
+      if (this.hasTargets) return localize(RuntimeConfig().procedure.challenge);
+      const atk = localize(RuntimeConfig().procedure.attack);
       const weapon = this.item?.name ?? "";
       return weapon ? `${atk} ${weapon}` : atk;
    }

--- a/module/services/procedure/FSM/ResistanceProcedure.js
+++ b/module/services/procedure/FSM/ResistanceProcedure.js
@@ -6,7 +6,9 @@ import OpposeRollService from "@services/OpposeRollService.js";
 import ResistanceEngine from "@rules/ResistanceEngine.js";
 import { localize } from "@services/utilities.js";
 
-const config = CONFIG.sr3e;
+function RuntimeConfig() {
+   return CONFIG?.sr3e || {};
+}
 
 export default class ResistanceProcedure extends AbstractProcedure {
    #prep;
@@ -82,7 +84,7 @@ export default class ResistanceProcedure extends AbstractProcedure {
    }
 
    getPrimaryActionLabel() {
-      return localize(config.procedure.resist);
+      return localize(RuntimeConfig().procedure.resist);
    }
 
    finalTN({ floor = 2 } = {}) {

--- a/module/services/procedure/FSM/SkillProcedure.js
+++ b/module/services/procedure/FSM/SkillProcedure.js
@@ -2,7 +2,9 @@ import AbstractProcedure from "@services/procedure/FSM/AbstractProcedure.js";
 import SR3ERoll from "@documents/SR3ERoll.js";
 import { localize } from "@services/utilities.js";
 
-const config = CONFIG.sr3e;
+function RuntimeConfig() {
+   return CONFIG?.sr3e || {};
+}
 
 export default class SkillProcedure extends AbstractProcedure {
   static KIND = "skill";


### PR DESCRIPTION
## Summary
- refactor procedure modules to use a RuntimeConfig helper instead of a static CONFIG reference
- replace all usages of CONFIG.sr3e with RuntimeConfig()

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ac15fd6c188325a640935b90607193