### PR TITLE
feat: allow generic responder basis selection

### DIFF
--- a/module/services/procedure/FSM/MeleeDefenseProcedure.js
+++ b/module/services/procedure/FSM/MeleeDefenseProcedure.js
@@ -15,11 +15,13 @@ export default class MeleeDefenseProcedure extends AbstractProcedure {
     this.args = args || {};
     this.mode = (this.args.mode === "full") ? "full" : "standard";   // "standard" | "full"
 
-    // Seed UI from hydrated basis (built in MeleeProcedure.buildDefenseProcedure)
-    const b = this.args.basis || {};
-    this.dice = Math.max(0, Number(b.dice ?? 0));
+    if (args?.basis) {
+      this.setResponderBasis(args.basis);
+      this.applyResponderBasisDice();
+    }
 
-    // Panel title
+    const b = this.getResponderBasis() || {};
+
     if (this.mode === "full") {
       const parry = localize(RuntimeConfig().procedure.parry);
       this.title = b?.type === "attribute"
@@ -50,7 +52,7 @@ export default class MeleeDefenseProcedure extends AbstractProcedure {
   // - STANDARD: base/basis + pool + karma
   // - FULL:     base/basis + karma   (no pool on this initial test)
   buildFormula(explodes = true) {
-    const b = this.args?.basis || {};
+    const b = this.getResponderBasis() || {};
     const baseDice  = Math.max(0, Math.floor(Number(b.dice ?? this.dice ?? 0)));
     const poolDice  = this.mode === "full" ? 0 : Math.max(0, Math.floor(Number(this.poolDice) || 0));
     const karmaDice = Math.max(0, Math.floor(Number(this.karmaDice) || 0));
@@ -70,7 +72,7 @@ export default class MeleeDefenseProcedure extends AbstractProcedure {
     if (this.mode === "full") this.poolDice = 0;
 
     // Safety: restore from basis if UI zeroed it
-    const b = this.args?.basis || {};
+    const b = this.getResponderBasis() || {};
     if ((this.dice | 0) <= 0) this.dice = Math.max(0, Number(b.dice ?? 0));
 
     const actor = this.caller;

--- a/module/svelte/apps/components/RollComposerComponent.svelte
+++ b/module/svelte/apps/components/RollComposerComponent.svelte
@@ -425,15 +425,12 @@
             // 1) Candidate basis from the composer (may be empty!)
             const candidate = foundry?.utils?.deepClone ? foundry.utils.deepClone(caller) : { ...caller };
             const hasValidType = candidate && typeof candidate.type === "string" && candidate.type.trim();
-            const hasDice = Number.isFinite(Number(candidate?.dice)) && Number(candidate.dice) > 0;
 
-            // 2) Only push a basis override if it’s meaningful.
-            //    Otherwise keep the hydrated basis that MeleeProcedure set.
-            if (hasValidType && hasDice) {
-               proc.args = proc.args || {};
-               proc.args.basis = candidate;
-               // Optional UI nicety: reflect the dice in the composer/proc if provided.
-               proc.dice = Math.max(0, Number(candidate.dice));
+            if (hasValidType) {
+               try {
+                  proc.setResponderBasis(candidate);
+                  proc.applyResponderBasisDice();
+               } catch {}
             }
 
             // 3) Karma + Pool
@@ -446,9 +443,9 @@
             }
 
             // 4) Debug & roll via the procedure (keeps logic in the chain, not here)
-            console.debug("DEF submit ->", {
+              console.debug("DEF submit ->", {
                kind: proc?.constructor?.name,
-               basis: proc?.args?.basis,
+               basis: proc.getResponderBasis?.(),
                dice: proc?.dice,
                pool: proc?.poolDice,
                karma: proc?.karmaDice,


### PR DESCRIPTION
## Summary
- support dynamic responder basis in AbstractProcedure (attributes or skills)
- update melee defense procedure to leverage responder basis helper
- wire roll composer to send responder basis and show updated debug

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ac483e930483259384a2e5dd4193f7