### PR TITLE
feat: preserve contested flow after basis change

### DIFF
--- a/module/services/procedure/FSM/AbstractProcedure.js
+++ b/module/services/procedure/FSM/AbstractProcedure.js
@@ -3,6 +3,7 @@ import { writable, derived, get, readable } from "svelte/store";
 import { localize } from "@services/utilities.js";
 import SR3ERoll from "@documents/SR3ERoll.js";
 import ProcedureLock from "@services/procedure/FSM/ProcedureLock.js";
+import OpposeRollService from "@services/OpposeRollService.js";
 
 function RuntimeConfig() {
    return CONFIG?.sr3e || {};
@@ -141,6 +142,8 @@ export default class AbstractProcedure {
    #subSkill = null;
    #specialization = null;
    #readwrite = null;
+   #contestId = null;
+   #responseBasis = null;
    #contestIds = [];
 
    #targetNumberStore;
@@ -422,6 +425,36 @@ export default class AbstractProcedure {
       return this.#contestIds.slice();
    }
 
+   setContestId(id) {
+      this.#contestId = id ?? null;
+   }
+
+   get contestId() {
+      return this.#contestId;
+   }
+
+   setResponseBasis(basis = null) {
+      this.#responseBasis = basis || null;
+
+      const n = Number(basis?.dice);
+      if (Number.isFinite(n)) this.dice = Math.max(0, Math.floor(n));
+
+      if (basis?.type === "attribute" && basis?.key) {
+         this.#linkedAttributeStore?.set?.(String(basis.key));
+      }
+   }
+
+   getResponseBasis() {
+      return this.#responseBasis;
+   }
+
+   deliverContestResponse(rollOrJson) {
+      const id = this.#contestId;
+      if (!id) return;
+      const payload = typeof rollOrJson?.toJSON === "function" ? rollOrJson.toJSON() : rollOrJson;
+      if (payload) OpposeRollService.deliverResponse(id, payload);
+   }
+
    get isOpposed() {
       return (game.user?.targets?.size ?? 0) > 0;
    }
@@ -605,50 +638,39 @@ export default class AbstractProcedure {
       // --- attach options (used later by contested message rendering) ------------
       const o = (baseRoll.options = baseRoll.options || {});
 
-      // Total & base dice (useful for debugging and UI summaries)
       if (o.baseDice == null) o.baseDice = baseDice;
       if (o.dice == null) o.dice = baseDice + poolDice + karmaDice;
 
-      // Karma
       if (karmaDice > 0 && o.karmaDice == null) o.karmaDice = karmaDice;
 
-      // Defaulting
       if (this.#isDefaulting) {
          const lk = get(this.#linkedAttributeStore);
          if (lk) {
-            o.attributeKey = lk; // helps the defender/attacker summary block label correctly
+            o.attributeKey = lk;
             o.defaulting = true;
          }
       }
 
-      // Pools (normalize into a single array so renderers don't guess)
       if (!Array.isArray(o.pools)) o.pools = [];
-
       const prettyPool = (k) => {
          if (!k) return "Pool";
-         // Try config label first, then prettify the key
          const label = CONFIG?.sr3e?.dicepools?.[k];
          if (label) return typeof game?.i18n?.localize === "function" ? game.i18n.localize(label) : String(label);
          return String(k)
             .replace(/([A-Z])/g, " $1")
-            .replace(/^\w/, (c) => c.toUpperCase()); // e.g., combatPool → Combat Pool
+            .replace(/^\w/, (c) => c.toUpperCase());
       };
 
       if (poolDice > 0) {
-         // If this roll has an associated pool key (from the linked skill), record both a
-         // key-specific field (for legacy consumers) AND a normalized pools[] entry.
          if (this.#associatedPoolKey) {
-            const key = `${this.#associatedPoolKey}Dice`; // e.g. "combatPoolDice"
+            const key = `${this.#associatedPoolKey}Dice`;
             if (o[key] == null) o[key] = poolDice;
             o.pools.push({ name: prettyPool(this.#associatedPoolKey), key: this.#associatedPoolKey, dice: poolDice });
          } else {
-            // Generic/unknown pool selection
             o.pools.push({ name: "Pool", key: "pool", dice: poolDice });
          }
       }
 
-      // TN snapshot for full transparency (base + individual modifiers + final)
-      // These reflect what the composer currently shows.
       const baseRaw = get(this.#targetNumberStore);
       const mods = (get(this.#modifiersArrayStore) ?? []).map((m) => ({
          id: m.id ?? null,
@@ -657,11 +679,37 @@ export default class AbstractProcedure {
       }));
       if (!Array.isArray(o.tnMods)) o.tnMods = mods.slice();
       if (o.tnBase == null) o.tnBase = baseRaw == null ? null : Number(baseRaw);
-      if (o.targetNumber == null)
+      if (o.targetNumber == null) {
          o.targetNumber =
             baseRaw == null
                ? null
                : Math.max(2, Number(baseRaw) + mods.reduce((a, m) => a + (Number(m.value) || 0), 0));
+      }
+
+      const basis = this.#responseBasis;
+      if (basis && typeof basis === "object") {
+         if (basis.type === "attribute") {
+            o.type = "attribute";
+            if (basis.key) o.attributeKey = String(basis.key);
+            if (basis.isDefaulting != null) o.isDefaulting = !!basis.isDefaulting;
+            if (Number.isFinite(Number(basis.dice))) o.attributeDice = Math.max(0, Math.floor(Number(basis.dice)));
+         } else if (basis.type === "skill") {
+            o.type = "skill";
+            o.skill = { id: basis.id ?? null, name: basis.name ?? "Skill" };
+            if (basis.specialization) o.specialization = basis.specialization;
+            if (Number.isFinite(Number(basis.specIndex))) o.specIndex = Number(basis.specIndex);
+            if (basis.poolKey) {
+               const sel = this.#computeClampedPoolDice(this.poolDice);
+               if (sel > 0) o.pools.push({ name: prettyPool(basis.poolKey), key: basis.poolKey, dice: sel });
+            }
+            if (Number.isFinite(Number(basis.dice))) o.skillDice = Math.max(0, Math.floor(Number(basis.dice)));
+         } else if (basis.type === "item") {
+            o.type = "item";
+            o.itemKey = basis.id ?? null;
+            if (basis.name) o.itemName = basis.name;
+            if (Number.isFinite(Number(basis.dice))) o.itemDice = Math.max(0, Math.floor(Number(basis.dice)));
+         }
+      }
    }
 
    /** Optional hook: run after the roll is fully resolved. Subclasses may override. */

--- a/module/services/procedure/FSM/AttributeResponseProcedure.js
+++ b/module/services/procedure/FSM/AttributeResponseProcedure.js
@@ -1,7 +1,6 @@
 // module/services/procedure/FSM/AttributeResponseProcedure.js
 import AbstractProcedure from "@services/procedure/FSM/AbstractProcedure.js";
 import SR3ERoll from "@documents/SR3ERoll.js";
-import OpposeRollService from "@services/OpposeRollService.js";
 import { localize } from "@services/utilities.js";
 
 function RuntimeConfig() { return CONFIG?.sr3e || {}; }
@@ -10,10 +9,10 @@ export default class AttributeResponseProcedure extends AbstractProcedure {
   static KIND = "attribute-response";
 
   #attrKey = "strength";
-  #contestId = null;
 
-  constructor(defender, _item = null, { attributeKey = "strength", title = null } = {}) {
+  constructor(defender, _item = null, { attributeKey = "strength", title = null, contestId = null } = {}) {
     super(defender, null, { lockPriority: "simple" });
+    this.setContestId(contestId);
     this.#attrKey = String(attributeKey || "strength").toLowerCase();
 
     const label = title || (RuntimeConfig().attributes?.[this.#attrKey] ?? this.#attrKey);
@@ -49,9 +48,7 @@ export default class AttributeResponseProcedure extends AbstractProcedure {
     await baseRoll.waitForResolution();
     await CommitEffects?.();
 
-    if (this.#contestId) {
-      OpposeRollService.deliverResponse(this.#contestId, roll.toJSON());
-    }
+    this.deliverContestResponse(roll);
 
     Hooks.callAll("actorSystemRecalculated", actor);
     await this.onChallengeResolved?.({ roll, actor });
@@ -59,7 +56,7 @@ export default class AttributeResponseProcedure extends AbstractProcedure {
   }
 
   async fromContestExport(exportCtx, { contestId } = {}) {
-    this.#contestId = contestId ?? null;
+    this.setContestId(contestId ?? null);
 
     const k = String(exportCtx?.attributeKey || this.#attrKey || "strength").toLowerCase();
     this.#attrKey = k;
@@ -72,9 +69,9 @@ export default class AttributeResponseProcedure extends AbstractProcedure {
     this.dice = Math.max(0, rating);
   }
 
-  toJSONExtra() { return { attributeKey: this.#attrKey, contestId: this.#contestId }; }
+  toJSONExtra() { return { attributeKey: this.#attrKey, contestId: this.contestId }; }
   async fromJSONExtra(extra) {
     if (extra?.attributeKey) this.#attrKey = String(extra.attributeKey).toLowerCase();
-    this.#contestId = extra?.contestId ?? this.#contestId;
+    this.setContestId(extra?.contestId ?? null);
   }
 }

--- a/module/services/procedure/FSM/DodgeProcedure.js
+++ b/module/services/procedure/FSM/DodgeProcedure.js
@@ -1,7 +1,6 @@
 // services/procedure/FSM/DodgeProcedure.js
 import AbstractProcedure from "@services/procedure/FSM/AbstractProcedure";
 import SR3ERoll from "@documents/SR3ERoll.js";
-import OpposeRollService from "@services/OpposeRollService.js";
 import { localize } from "@services/utilities.js";
 
 function RuntimeConfig() {
@@ -11,15 +10,12 @@ function RuntimeConfig() {
 export default class DodgeProcedure extends AbstractProcedure {
    static kind = "dodge";
 
-   #contestId = null;
-
    constructor(defender, _noItem = null, { contestId } = {}) {
       super(defender, null);
 
       this.title = localize(RuntimeConfig().procedure.dodgetitle);
-      this.#contestId = contestId ?? null;
+      this.setContestId(contestId ?? null);
 
-      // Base TN 4
       this.targetNumberStore?.set?.(4);
    }
 
@@ -61,11 +57,7 @@ export default class DodgeProcedure extends AbstractProcedure {
 
       await CommitEffects?.();
 
-      if (!this.#contestId) {
-         console.warn("[sr3e] DodgeProcedure missing contestId; cannot deliver response");
-      } else {
-         OpposeRollService.deliverResponse(this.#contestId, roll.toJSON());
-      }
+      this.deliverContestResponse(roll);
 
       Hooks.callAll("actorSystemRecalculated", actor);
       await this.onChallengeResolved?.({ roll, actor });

--- a/module/services/procedure/FSM/MeleeDefenseProcedure.js
+++ b/module/services/procedure/FSM/MeleeDefenseProcedure.js
@@ -15,16 +15,19 @@ export default class MeleeDefenseProcedure extends AbstractProcedure {
     this.args = args || {};
     this.mode = (this.args.mode === "full") ? "full" : "standard";   // "standard" | "full"
 
-    // Seed UI from hydrated basis (built in MeleeProcedure.buildDefenseProcedure)
+    // Bind contest id so we can deliver the reply
+    this.setContestId(this.args?.contestId ?? null);
+
+    // Seed UI from hydrated basis
     const b = this.args.basis || {};
-    this.dice = Math.max(0, Number(b.dice ?? 0));
+    this.setResponseBasis(b); // sets dice, linked attribute, etc.
 
     // Panel title
     if (this.mode === "full") {
       const parry = localize(RuntimeConfig().procedure.parry);
       this.title = b?.type === "attribute"
         ? `${parry} (${cap(b.key)})`
-        : `${parry} (${b?.name})`;
+        : `${parry} (${b?.name || "Defense"})`;
     } else {
       this.title = localize(RuntimeConfig().procedure.standardDefense);
     }
@@ -66,10 +69,8 @@ export default class MeleeDefenseProcedure extends AbstractProcedure {
   async execute({ OnClose } = {}) {
     OnClose?.();
 
-    // Enforce “no pool” on Full Defense initial test
     if (this.mode === "full") this.poolDice = 0;
 
-    // Safety: restore from basis if UI zeroed it
     const b = this.args?.basis || {};
     if ((this.dice | 0) <= 0) this.dice = Math.max(0, Number(b.dice ?? 0));
 
@@ -77,18 +78,20 @@ export default class MeleeDefenseProcedure extends AbstractProcedure {
     const roll  = await SR3ERoll.create(this.buildFormula(true), { actor }).evaluate(this);
     await roll.waitForResolution();
 
-    // Tag the roll so your contested resolver can branch
-    const o = (roll.toJSON().options = { ...(roll.options || {}), meleeDefenseMode: this.mode });
-    o.testName = this.getFlavor();
+    const json = roll.toJSON();
+    json.options = { ...(json.options || {}), meleeDefenseMode: this.mode, testName: this.getFlavor() };
     if (b?.type === "attribute") {
-      o.attributeKey   = String(b.key || "strength");
-      o.isDefaulting   = b.isDefaulting ?? true;
-      if (Number.isFinite(Number(b.dice))) o.attributeDice = Number(b.dice);
+      json.options.attributeKey = String(b.key || "strength");
+      json.options.isDefaulting = b.isDefaulting ?? true;
+      if (Number.isFinite(Number(b.dice))) json.options.attributeDice = Number(b.dice);
     } else if (b?.type === "skill") {
-      o.skill = { id: b.id, name: b.name };
-      if (b.specialization) o.specialization = b.specialization;
-      if (Number.isFinite(Number(b.dice))) o.skillDice = Number(b.dice);
+      json.options.skill = { id: b.id, name: b.name };
+      if (b.specialization) json.options.specialization = b.specialization;
+      if (Number.isFinite(Number(b.dice))) json.options.skillDice = Number(b.dice);
     }
+
+    this.deliverContestResponse(json);
+
     return roll;
   }
 }

--- a/module/svelte/apps/components/RollComposerComponent.svelte
+++ b/module/svelte/apps/components/RollComposerComponent.svelte
@@ -430,10 +430,12 @@
             // 2) Only push a basis override if it’s meaningful.
             //    Otherwise keep the hydrated basis that MeleeProcedure set.
             if (hasValidType && hasDice) {
+               proc.setResponseBasis?.(candidate);
                proc.args = proc.args || {};
                proc.args.basis = candidate;
-               // Optional UI nicety: reflect the dice in the composer/proc if provided.
-               proc.dice = Math.max(0, Number(candidate.dice));
+               if (Number.isFinite(Number(candidate.dice))) {
+                  proc.dice = Math.max(0, Number(candidate.dice));
+               }
             }
 
             // 3) Karma + Pool


### PR DESCRIPTION
## Summary
- track active contest and response basis in `AbstractProcedure`
- keep dodge and melee defense responses in contest via `deliverContestResponse`
- allow roll composer to update defender's basis without restarting

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: Could not resolve "../../svelte/apps/metatypeApp.svelte")

------
https://chatgpt.com/codex/tasks/task_e_68ac931f089c83259af2f1f520c76bc5