### PR TITLE
feat: preserve contested flow after basis change

### DIFF
--- a/module/services/procedure/FSM/AbstractProcedure.js
+++ b/module/services/procedure/FSM/AbstractProcedure.js
@@ -3,6 +3,7 @@ import { writable, derived, get, readable } from "svelte/store";
 import { localize } from "@services/utilities.js";
 import SR3ERoll from "@documents/SR3ERoll.js";
 import ProcedureLock from "@services/procedure/FSM/ProcedureLock.js";
+import OpposeRollService from "@services/OpposeRollService.js";
 
 function RuntimeConfig() {
    return CONFIG?.sr3e || {};
@@ -141,6 +142,8 @@ export default class AbstractProcedure {
    #subSkill = null;
    #specialization = null;
    #readwrite = null;
+   #contestId = null;
+   #responseBasis = null;
    #contestIds = [];
 
    #targetNumberStore;
@@ -422,6 +425,36 @@ export default class AbstractProcedure {
       return this.#contestIds.slice();
    }
 
+   setContestId(id) {
+      this.#contestId = id ?? null;
+   }
+
+   get contestId() {
+      return this.#contestId;
+   }
+
+   setResponseBasis(basis = null) {
+      this.#responseBasis = basis || null;
+
+      const n = Number(basis?.dice);
+      if (Number.isFinite(n)) this.dice = Math.max(0, Math.floor(n));
+
+      if (basis?.type === "attribute" && basis?.key) {
+         this.#linkedAttributeStore?.set?.(String(basis.key));
+      }
+   }
+
+   getResponseBasis() {
+      return this.#responseBasis;
+   }
+
+   deliverContestResponse(rollOrJson) {
+      const id = this.#contestId;
+      if (!id) return;
+      const payload = typeof rollOrJson?.toJSON === "function" ? rollOrJson.toJSON() : rollOrJson;
+      if (payload) OpposeRollService.deliverResponse(id, payload);
+   }
+
    get isOpposed() {
       return (game.user?.targets?.size ?? 0) > 0;
    }
@@ -605,50 +638,39 @@ export default class AbstractProcedure {
       // --- attach options (used later by contested message rendering) ------------
       const o = (baseRoll.options = baseRoll.options || {});
 
-      // Total & base dice (useful for debugging and UI summaries)
       if (o.baseDice == null) o.baseDice = baseDice;
       if (o.dice == null) o.dice = baseDice + poolDice + karmaDice;
 
-      // Karma
       if (karmaDice > 0 && o.karmaDice == null) o.karmaDice = karmaDice;
 
-      // Defaulting
       if (this.#isDefaulting) {
          const lk = get(this.#linkedAttributeStore);
          if (lk) {
-            o.attributeKey = lk; // helps the defender/attacker summary block label correctly
+            o.attributeKey = lk;
             o.defaulting = true;
          }
       }
 
-      // Pools (normalize into a single array so renderers don't guess)
       if (!Array.isArray(o.pools)) o.pools = [];
-
       const prettyPool = (k) => {
          if (!k) return "Pool";
-         // Try config label first, then prettify the key
          const label = CONFIG?.sr3e?.dicepools?.[k];
          if (label) return typeof game?.i18n?.localize === "function" ? game.i18n.localize(label) : String(label);
          return String(k)
             .replace(/([A-Z])/g, " $1")
-            .replace(/^\w/, (c) => c.toUpperCase()); // e.g., combatPool → Combat Pool
+            .replace(/^\w/, (c) => c.toUpperCase());
       };
 
       if (poolDice > 0) {
-         // If this roll has an associated pool key (from the linked skill), record both a
-         // key-specific field (for legacy consumers) AND a normalized pools[] entry.
          if (this.#associatedPoolKey) {
-            const key = `${this.#associatedPoolKey}Dice`; // e.g. "combatPoolDice"
+            const key = `${this.#associatedPoolKey}Dice`;
             if (o[key] == null) o[key] = poolDice;
             o.pools.push({ name: prettyPool(this.#associatedPoolKey), key: this.#associatedPoolKey, dice: poolDice });
          } else {
-            // Generic/unknown pool selection
             o.pools.push({ name: "Pool", key: "pool", dice: poolDice });
          }
       }
 
-      // TN snapshot for full transparency (base + individual modifiers + final)
-      // These reflect what the composer currently shows.
       const baseRaw = get(this.#targetNumberStore);
       const mods = (get(this.#modifiersArrayStore) ?? []).map((m) => ({
          id: m.id ?? null,
@@ -657,11 +679,37 @@ export default class AbstractProcedure {
       }));
       if (!Array.isArray(o.tnMods)) o.tnMods = mods.slice();
       if (o.tnBase == null) o.tnBase = baseRaw == null ? null : Number(baseRaw);
-      if (o.targetNumber == null)
+      if (o.targetNumber == null) {
          o.targetNumber =
             baseRaw == null
                ? null
                : Math.max(2, Number(baseRaw) + mods.reduce((a, m) => a + (Number(m.value) || 0), 0));
+      }
+
+      const basis = this.#responseBasis;
+      if (basis && typeof basis === "object") {
+         if (basis.type === "attribute") {
+            o.type = "attribute";
+            if (basis.key) o.attributeKey = String(basis.key);
+            if (basis.isDefaulting != null) o.isDefaulting = !!basis.isDefaulting;
+            if (Number.isFinite(Number(basis.dice))) o.attributeDice = Math.max(0, Math.floor(Number(basis.dice)));
+         } else if (basis.type === "skill") {
+            o.type = "skill";
+            o.skill = { id: basis.id ?? null, name: basis.name ?? "Skill" };
+            if (basis.specialization) o.specialization = basis.specialization;
+            if (Number.isFinite(Number(basis.specIndex))) o.specIndex = Number(basis.specIndex);
+            if (basis.poolKey) {
+               const sel = this.#computeClampedPoolDice(this.poolDice);
+               if (sel > 0) o.pools.push({ name: prettyPool(basis.poolKey), key: basis.poolKey, dice: sel });
+            }
+            if (Number.isFinite(Number(basis.dice))) o.skillDice = Math.max(0, Math.floor(Number(basis.dice)));
+         } else if (basis.type === "item") {
+            o.type = "item";
+            o.itemKey = basis.id ?? null;
+            if (basis.name) o.itemName = basis.name;
+            if (Number.isFinite(Number(basis.dice))) o.itemDice = Math.max(0, Math.floor(Number(basis.dice)));
+         }
+      }
    }
 
    /** Optional hook: run after the roll is fully resolved. Subclasses may override. */
@@ -710,7 +758,8 @@ export default class AbstractProcedure {
       if (!DefenseCtor) {
          throw new Error(`No registered procedure for kind="${kind}"`);
       }
-      const proc = new DefenseCtor(defender, /* item */ null);
+      const baseArgs = exportCtx?.next?.args || {};
+      const proc = new DefenseCtor(defender, /* item */ null, { ...baseArgs, contestId });
       if (typeof proc.fromContestExport === "function") {
          await proc.fromContestExport(exportCtx, { contestId, initiatorExport: exportCtx });
       }

--- a/module/services/procedure/FSM/DodgeProcedure.js
+++ b/module/services/procedure/FSM/DodgeProcedure.js
@@ -1,7 +1,6 @@
 // services/procedure/FSM/DodgeProcedure.js
 import AbstractProcedure from "@services/procedure/FSM/AbstractProcedure";
 import SR3ERoll from "@documents/SR3ERoll.js";
-import OpposeRollService from "@services/OpposeRollService.js";
 import { localize } from "@services/utilities.js";
 
 function RuntimeConfig() {
@@ -11,15 +10,12 @@ function RuntimeConfig() {
 export default class DodgeProcedure extends AbstractProcedure {
    static kind = "dodge";
 
-   #contestId = null;
-
    constructor(defender, _noItem = null, { contestId } = {}) {
       super(defender, null);
 
       this.title = localize(RuntimeConfig().procedure.dodgetitle);
-      this.#contestId = contestId ?? null;
+      this.setContestId(contestId ?? null);
 
-      // Base TN 4
       this.targetNumberStore?.set?.(4);
    }
 
@@ -61,11 +57,7 @@ export default class DodgeProcedure extends AbstractProcedure {
 
       await CommitEffects?.();
 
-      if (!this.#contestId) {
-         console.warn("[sr3e] DodgeProcedure missing contestId; cannot deliver response");
-      } else {
-         OpposeRollService.deliverResponse(this.#contestId, roll.toJSON());
-      }
+      this.deliverContestResponse(roll);
 
       Hooks.callAll("actorSystemRecalculated", actor);
       await this.onChallengeResolved?.({ roll, actor });

--- a/module/services/procedure/FSM/SkillResponseProcedure.js
+++ b/module/services/procedure/FSM/SkillResponseProcedure.js
@@ -1,7 +1,6 @@
 // services/procedure/FSM/SkillResponseProcedure.js
 import AbstractProcedure from "@services/procedure/FSM/AbstractProcedure.js";
 import SR3ERoll from "@documents/SR3ERoll.js";
-import OpposeRollService from "@services/OpposeRollService.js";
 import { localize } from "@services/utilities.js";
 
 function C() { return CONFIG?.sr3e || {}; }
@@ -13,11 +12,11 @@ export default class SkillResponseProcedure extends AbstractProcedure {
   #skillName = "Skill";
   #specName = null;
   #poolKey = null;
-  #contestId = null;
 
-  constructor(defender, _noItem = null, _args = {}) {
+  constructor(defender, _noItem = null, args = {}) {
     super(defender, null, { lockPriority: "simple" });
     this.title = `${this.#skillName} Response`;
+    if (args?.contestId) this.setContestId(args.contestId);
   }
 
   get hasTargets() { return false; }
@@ -47,17 +46,29 @@ export default class SkillResponseProcedure extends AbstractProcedure {
     await roll.waitForResolution();
     await CommitEffects?.();
 
-    if (this.#contestId) {
-      OpposeRollService.deliverResponse(this.#contestId, roll.toJSON());
-    }
+    this.deliverContestResponse(roll);
 
     Hooks.callAll("actorSystemRecalculated", actor);
     await this.onChallengeResolved?.({ roll, actor });
     return roll;
   }
 
+  setResponseBasis(basis = null) {
+    super.setResponseBasis(basis);
+    const b = basis || {};
+    if (b.type === "skill") {
+      this.#skillId   = b.id   ?? this.#skillId;
+      this.#skillName = b.name ?? this.#skillName;
+      this.#specName  = b.specialization ?? this.#specName;
+      this.#poolKey   = b.poolKey ?? this.#poolKey;
+      const n = Number(b.dice);
+      if (Number.isFinite(n)) this.dice = Math.max(0, Math.floor(n));
+      this.title = `${this.#skillName} Response`;
+    }
+  }
+
   async fromContestExport(exportCtx, { contestId } = {}) {
-    this.#contestId = contestId ?? null;
+    this.setContestId(contestId ?? null);
 
     const idFromExport = exportCtx?.skillId ?? null;
     const skill = idFromExport ? this.caller?.items?.get?.(idFromExport) : null;
@@ -85,7 +96,7 @@ export default class SkillResponseProcedure extends AbstractProcedure {
 
   toJSONExtra() {
     return {
-      contestId: this.#contestId,
+      contestId: this.contestId,
       skillId:   this.#skillId,
       specName:  this.#specName,
       poolKey:   this.#poolKey,
@@ -93,7 +104,7 @@ export default class SkillResponseProcedure extends AbstractProcedure {
     };
   }
   async fromJSONExtra(extra) {
-    this.#contestId = extra?.contestId ?? this.#contestId;
+    this.setContestId(extra?.contestId ?? null);
     this.#skillId   = extra?.skillId   ?? this.#skillId;
     this.#specName  = extra?.specName  ?? this.#specName;
     this.#poolKey   = extra?.poolKey   ?? this.#poolKey;

--- a/module/svelte/apps/components/RollComposerComponent.svelte
+++ b/module/svelte/apps/components/RollComposerComponent.svelte
@@ -7,6 +7,8 @@
    import FirearmService from "@families/FirearmService.js";
    import AbstractProcedure from "@services/procedure/FSM/AbstractProcedure.js";
    import FirearmProcedure from "@services/procedure/FSM/FirearmProcedure.js";
+   import AttributeProcedure from "@services/procedure/FSM/AttributeProcedure.js";
+   import SkillProcedure from "@services/procedure/FSM/SkillProcedure.js";
    import { recoilState, clearAllRecoilForActor } from "@services/ComposerAttackController.js";
 
    let { actor, config } = $props();
@@ -140,6 +142,36 @@
 
    export function setCallerData(currentProcedure) {
       if (!(currentProcedure instanceof AbstractProcedure)) throw new Error("Unfit data type");
+
+      const existing = $procedureStore;
+      const inContest = existing?.contestId && typeof existing.setResponseBasis === "function";
+      const isBasisProc = currentProcedure instanceof AttributeProcedure || currentProcedure instanceof SkillProcedure;
+      if (existing && inContest && isBasisProc) {
+         let basis = null;
+         if (currentProcedure instanceof AttributeProcedure) {
+            const extra = currentProcedure.toJSONExtra?.() || {};
+            basis = { type: "attribute", key: extra.attributeKey, dice: currentProcedure.dice };
+         } else if (currentProcedure instanceof SkillProcedure) {
+            const extra = currentProcedure.toJSONExtra?.() || {};
+            basis = {
+               type: "skill",
+               id: extra.skillId ?? null,
+               name: extra.skillName ?? "Skill",
+               specialization: extra.specName ?? null,
+               poolKey: extra.poolKey ?? null,
+               dice: currentProcedure.dice,
+            };
+         }
+         if (basis) {
+            existing.setResponseBasis(basis);
+            existing.args = existing.args || {};
+            existing.args.basis = basis;
+            if (Number.isFinite(Number(basis.dice))) existing.dice = Math.max(0, Math.floor(Number(basis.dice)));
+            caller = { ...caller, ...basis };
+         }
+         return;
+      }
+
       clearStoreSubscriptions();
       $procedureStore = currentProcedure;
 
@@ -205,12 +237,22 @@
 
    $effect(() => {
       if (!visible) return;
-      caller;
+      const proc = $procedureStore;
+      const basis = caller;
       hasTargets;
       declaredRounds;
       weaponMode;
       phaseKey;
-      $procedureStore?.syncRecoil?.({ declaredRounds, ammoAvailable });
+
+      if (proc && basis && typeof basis.type === "string" && basis.type.trim()) {
+         proc.setResponseBasis?.(basis);
+         proc.args = proc.args || {};
+         proc.args.basis = basis;
+         if (Number.isFinite(Number(basis.dice))) {
+            proc.dice = Math.max(0, Math.floor(Number(basis.dice)));
+         }
+      }
+      proc?.syncRecoil?.({ declaredRounds, ammoAvailable });
    });
 
    $effect(() => {
@@ -422,21 +464,7 @@
             const proc = $procedureStore;
             if (!proc) return;
 
-            // 1) Candidate basis from the composer (may be empty!)
-            const candidate = foundry?.utils?.deepClone ? foundry.utils.deepClone(caller) : { ...caller };
-            const hasValidType = candidate && typeof candidate.type === "string" && candidate.type.trim();
-            const hasDice = Number.isFinite(Number(candidate?.dice)) && Number(candidate.dice) > 0;
-
-            // 2) Only push a basis override if it’s meaningful.
-            //    Otherwise keep the hydrated basis that MeleeProcedure set.
-            if (hasValidType && hasDice) {
-               proc.args = proc.args || {};
-               proc.args.basis = candidate;
-               // Optional UI nicety: reflect the dice in the composer/proc if provided.
-               proc.dice = Math.max(0, Number(candidate.dice));
-            }
-
-            // 3) Karma + Pool
+            // Karma + Pool
             proc.karmaDice = Math.max(0, Number(diceBought) || 0);
             if (proc?.constructor?.name === "MeleeFullDefenseProcedure") {
                // Full Defense initial test ignores pool
@@ -445,7 +473,7 @@
                proc.poolDice = Math.max(0, Number(currentDicePoolAddition) || 0);
             }
 
-            // 4) Debug & roll via the procedure (keeps logic in the chain, not here)
+            // Debug & roll via the procedure (keeps logic in the chain, not here)
             console.debug("DEF submit ->", {
                kind: proc?.constructor?.name,
                basis: proc?.args?.basis,


### PR DESCRIPTION
## Summary
- allow attribute and skill response procedures to retarget basis mid-contest
- treat attribute/skill selection in roll composer as a basis swap on the existing defender procedure
- keep contested result when defender switches attributes or skills

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: Could not resolve "../../svelte/apps/metatypeApp.svelte" from "module/foundry/sheets/MetatypeItemSheet.js")

------
https://chatgpt.com/codex/tasks/task_e_68ac931f089c83259af2f1f520c76bc5