### PR TITLE
Respect attribute limits for karma purchases

### DIFF
--- a/module/services/shopping/AttributeKarmaShopping.js
+++ b/module/services/shopping/AttributeKarmaShopping.js
@@ -9,9 +9,9 @@ function attributeMaximumFromRML(rml) {
 }
 
 export default class AttributeKarmaShopping extends BaseAttributeShopping {
-  constructor({ actor, key, storeManager, rml, disallowRaise, isShoppingStateStore }) {
-    const max = attributeMaximumFromRML(rml);
-    super({ actor, key, storeManager, rml, max, disallowRaise });
+  constructor({ actor, key, storeManager, rml, max, disallowRaise, isShoppingStateStore }) {
+    const computedMax = max ?? attributeMaximumFromRML(rml);
+    super({ actor, key, storeManager, rml, max: computedMax, disallowRaise });
 
     this.goodKarma = storeManager.GetRWStore("karma.goodKarma");
     this.spentKarma = storeManager.GetRWStore("karma.spentKarma");

--- a/module/svelte/apps/components/basic/AttributeCard.svelte
+++ b/module/svelte/apps/components/basic/AttributeCard.svelte
@@ -33,6 +33,8 @@
   let rml = $derived(
     key === "magic" || !metatype ? null : (metatype.system.attributeLimits?.[key] ?? null)
   );
+  // Karma purchases can exceed the racial limit up to 1.5× RML
+  let karmaMax = $derived(rml == null ? null : Math.floor(rml * 1.5));
 
   // Resources
   let creationPointsStore = storeManager.GetRWStore("creation.attributePoints");
@@ -108,6 +110,7 @@
         key,
         storeManager,
         rml: rml ?? null,
+        max: karmaMax ?? null,
         disallowRaise: disallowKarmaRaise,
         isShoppingStateStore: isShoppingState
       });


### PR DESCRIPTION
## Summary
- ensure AttributeCard passes racial limit-based maximum to karma shopping logic
- allow AttributeKarmaShopping to accept an explicit max value

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Could not resolve "../../svelte/apps/metatypeApp.svelte")*

------
https://chatgpt.com/codex/tasks/task_e_68b0387749708325a5e99666f853b76c