### PR TITLE
Add Attribute and Skill Randomizers to character creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,19 @@ sr3e is a Shadowrun Third Edition Homebrew game system for Foundry Virtual Table
 
 ## Beta release
 
-This is the first beta release of sr3e — the system is now playable end to end. It is still a hobby project developed in spare time, so expect rough edges, missing rules, and the occasional bug. If you run into one, please [report it](#contributing) — that's exactly what a beta is for.
+This is the first beta release of sr3e - the system is now playable end to end. It is still a hobby project developed in spare time, so expect rough edges, missing rules, and the occasional bug. If you run into one, please [report it](#contributing), that's exactly what a beta is for.
 
 ## Architecture overview
 
-The system follows a four-layer model: **Svelte UI → Service Layer → IStoreManager → Foundry VTT**. Actor and item sheets are built with Svelte 5 components that never touch Foundry documents directly — they read and write through a game-wide `IStoreManager` singleton, which is the only layer that talks to Foundry's actor/item/effect APIs. Rules and business logic live in a service layer beneath the UI, keeping components focused on presentation and services free of framework concerns. DataModels (rather than a legacy `template.json`) define the actor and item schemas.
+The system follows a four-layer model: **Svelte UI -> Service Layer -> IStoreManager -> Foundry VTT**. Actor and item sheets are built with Svelte 5 components that never touch Foundry documents directly, they read and write through a game-wide `IStoreManager` singleton, which is the only layer that talks to Foundry's actor/item/effect APIs. Rules and business logic live in a service layer beneath the UI, keeping components focused on presentation and services free of framework concerns. DataModels (rather than a legacy `template.json`) define the actor and item schemas.
 
 ## Localization
 
-Translation strings are not hand-maintained in `lang/*.json`. Each config module under `lang/config/` declares the set of keys a category needs in TypeScript; a Vite plugin (`vite-plugins/i18n-scaffold.ts`) scans those declarations on every build and scaffolds the locale JSON files automatically — adding new keys with a placeholder value, pruning keys that no longer exist, and leaving existing translations untouched. This keeps every locale file in sync with the code without anyone having to remember to update them by hand. Translating the system is just a matter of editing the values in the relevant `lang/<locale>.json` file.
+Translation strings are not hand-maintained in `lang/*.json`. Each config module under `lang/config/` declares the set of keys a category needs in TypeScript; a Vite plugin (`vite-plugins/i18n-scaffold.ts`) scans those declarations on every build and scaffolds the locale JSON files automatically, adding new keys with a placeholder value, pruning keys that no longer exist, and leaving existing translations untouched. This keeps every locale file in sync with the code without anyone having to remember to update them by hand. Translating the system is just a matter of editing the values in the relevant `lang/<locale>.json` file.
 
 ## Icon credit
 
-Icons used throughout the system are sourced from [SVG Repo](https://www.svgrepo.com/), an open-source icon repository. Thank you to the artists whose freely licensed work makes this project more presentable — see `textures/svgrepo/` for the icons in use.
+Icons used throughout the system are sourced from [SVG Repo](https://www.svgrepo.com/), an open-source icon repository. Thank you to the artists whose freely licensed work makes this project more presentable, see `textures/svgrepo/` for the icons in use.
 
 ## Texture credit
 
@@ -26,11 +26,11 @@ The texture for the character sheet is from https://ambientcg.com/
 
 ## AI-assisted development
 
-Parts of this project — code, documentation, and tooling — have been developed with the assistance of AI. This is disclosed in the interest of transparency. First iteration was made mostly by old fashion hand coding, including the visual design. Second iteration has been more AI-heavy. If you want to program you are welcome to use AI, but be sure to verify its output, and align it to the projects over all structure.
+Parts of this project (code, documentation, and tooling) have been developed with the assistance of AI. This is disclosed in the interest of transparency. First iteration was made mostly by old fashion hand coding, including the visual design. Second iteration has been more AI-heavy. If you want to program you are welcome to use AI, but be sure to verify its output, and align it to the projects over all structure.
 
 ## Contributing
 
-Contributions, bug reports, and feature requests are all welcome. If you'd like to report a bug or suggest an improvement, please use the issue templates on GitHub — they help route your report to the right place. If you'd like to contribute code or documentation you are welcome to tag along this sr3e adventure.
+Contributions, bug reports, and feature requests are all welcome. If you'd like to report a bug or suggest an improvement, please use the issue templates on GitHub, they help route your report to the right place. If you'd like to contribute code or documentation you are welcome to tag along this sr3e adventure.
 
 ## What is Shadowrun Third Edition
 

--- a/lang/config/SkillConfig.ts
+++ b/lang/config/SkillConfig.ts
@@ -13,4 +13,6 @@ export const SKILL_KEYS = [
   "onlyonespecializationatcreation",
   "linkedAttribute",
   "specialize",
+  "sorcery",
+  "conjuring",
   ] as const;

--- a/lang/en.json
+++ b/lang/en.json
@@ -587,6 +587,7 @@
     "skill": {
       "active": "Active",
       "addlingo": "Add Lingo",
+      "conjuring": "Conjuring",
       "knowledge": "Knowledge",
       "language": "Language",
       "lingos": "Lingos",
@@ -595,6 +596,7 @@
       "onlyonespecializationatcreation": "You can only have one specialization during character creation.",
       "readwrite": "Read/Write",
       "skill": "Skill",
+      "sorcery": "Sorcery",
       "specialization": "Specialization",
       "specializations": "Specializations",
       "specialize": "Specialize",

--- a/module/services/character-creation/AttributeRandomizerService.test.ts
+++ b/module/services/character-creation/AttributeRandomizerService.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { BUYABLE_ATTRIBUTES, randomizeAttributes, type RacialLimits } from "./AttributeRandomizerService";
+
+function limits(max: number): RacialLimits {
+	return BUYABLE_ATTRIBUTES.reduce((acc, key) => {
+		acc[key] = max;
+		return acc;
+	}, {} as RacialLimits);
+}
+
+function sum(values: Record<string, number>): number {
+	return Object.values(values).reduce((total, value) => total + value, 0);
+}
+
+describe("randomizeAttributes", () => {
+	it("spends the entire pool when headroom is available", () => {
+		const result = randomizeAttributes(24, limits(6));
+
+		expect(sum(result) - BUYABLE_ATTRIBUTES.length).toBe(24);
+	});
+
+	it("never exceeds any attribute's racial maximum", () => {
+		const racialLimits = limits(6);
+		const result = randomizeAttributes(24, racialLimits);
+
+		for (const key of BUYABLE_ATTRIBUTES) {
+			expect(result[key]).toBeLessThanOrEqual(racialLimits[key]);
+		}
+	});
+
+	it("never drops any attribute below the baseline of 1", () => {
+		const result = randomizeAttributes(24, limits(6));
+
+		for (const key of BUYABLE_ATTRIBUTES) {
+			expect(result[key]).toBeGreaterThanOrEqual(1);
+		}
+	});
+
+	it("caps every attribute and stops early when the pool exceeds total headroom", () => {
+		// Headroom to cap: 6 attributes x (6 - 1) = 30. Pool of 100 must not overflow.
+		const racialLimits = limits(6);
+		const result = randomizeAttributes(100, racialLimits);
+
+		for (const key of BUYABLE_ATTRIBUTES) {
+			expect(result[key]).toBe(racialLimits[key]);
+		}
+	});
+
+	it("is deterministic under an injected RNG", () => {
+		const scripted = [0, 0.99, 0.5, 0.2, 0.8, 0.1];
+		let call = 0;
+		const rng = () => scripted[call++ % scripted.length]!;
+
+		const first = randomizeAttributes(10, limits(6), rng);
+		call = 0;
+		const second = randomizeAttributes(10, limits(6), rng);
+
+		expect(first).toEqual(second);
+	});
+
+	it("respects per-attribute racial limits (not just a uniform cap)", () => {
+		const racialLimits: RacialLimits = {
+			strength: 2,
+			quickness: 6,
+			body: 6,
+			charisma: 6,
+			intelligence: 6,
+			willpower: 6,
+		};
+
+		const result = randomizeAttributes(20, racialLimits);
+
+		expect(result.strength).toBeLessThanOrEqual(2);
+		expect(sum(result) - BUYABLE_ATTRIBUTES.length).toBe(20);
+	});
+});

--- a/module/services/character-creation/AttributeRandomizerService.ts
+++ b/module/services/character-creation/AttributeRandomizerService.ts
@@ -1,0 +1,46 @@
+/**
+ * Pure allocation algorithm for randomizing attribute points during character creation.
+ * Takes plain data in, returns plain data out — no Actor, store, or Foundry API dependency.
+ */
+
+export const BUYABLE_ATTRIBUTES = ["strength", "quickness", "body", "charisma", "intelligence", "willpower"] as const;
+
+export type BuyableAttributeKey = (typeof BUYABLE_ATTRIBUTES)[number];
+
+export type RacialLimits = Record<BuyableAttributeKey, number>;
+
+export type AttributeValues = Record<BuyableAttributeKey, number>;
+
+const ATTRIBUTE_BASELINE = 1;
+
+/**
+ * Randomly distributes totalPoints across the six buyable attributes, one point at a time,
+ * to attributes that have not yet reached their racial maximum. Stops when the pool is
+ * exhausted or every attribute is capped.
+ *
+ * @param randomSource - Injectable RNG in [0, 1); defaults to Math.random. Pass a seeded
+ * generator in tests for deterministic assertions.
+ */
+export function randomizeAttributes(
+	totalPoints: number,
+	racialLimits: RacialLimits,
+	randomSource: () => number = Math.random
+): AttributeValues {
+	const values: AttributeValues = BUYABLE_ATTRIBUTES.reduce((acc, key) => {
+		acc[key] = ATTRIBUTE_BASELINE;
+		return acc;
+	}, {} as AttributeValues);
+
+	let remainingPoints = totalPoints;
+
+	while (remainingPoints > 0) {
+		const eligible = BUYABLE_ATTRIBUTES.filter((key) => values[key] < racialLimits[key]);
+		if (eligible.length === 0) break;
+
+		const pick = eligible[Math.floor(randomSource() * eligible.length)]!;
+		values[pick]++;
+		remainingPoints--;
+	}
+
+	return values;
+}

--- a/module/services/character-creation/CharacterCreationService.test.ts
+++ b/module/services/character-creation/CharacterCreationService.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+import { CharacterCreationService } from "./CharacterCreationService";
+
+(globalThis as Record<string, unknown>).CONFIG = {
+	SR3E: { SKILL: { sorcery: "sr3e.skill.sorcery", conjuring: "sr3e.skill.conjuring" } },
+};
+
+function existingSkillItem(name: string, linkedAttribute: string) {
+	return {
+		id: name,
+		name,
+		type: "skill",
+		system: { skillType: "active", activeSkill: { linkedAttribute } },
+	};
+}
+
+function setup(items: unknown[]): { createSpy: ReturnType<typeof vi.fn> } {
+	const createSpy = vi.fn().mockResolvedValue(undefined);
+	(globalThis as Record<string, unknown>).Item = { create: createSpy };
+	(globalThis as Record<string, unknown>).game = {
+		i18n: {
+			localize: (key: string) =>
+				key === "sr3e.skill.sorcery" ? "Sorcery" : key === "sr3e.skill.conjuring" ? "Conjuring" : key,
+		},
+		items,
+	};
+	return { createSpy };
+}
+
+function skillCreations(createSpy: ReturnType<typeof vi.fn>) {
+	return createSpy.mock.calls.filter((call) => (call[0] as { type?: string }).type === "skill");
+}
+
+describe("CharacterCreationService.ensureDefaultItemsExist (Sorcery/Conjuring bootstrap)", () => {
+	it("creates Sorcery and Conjuring when neither exists", async () => {
+		const { createSpy } = setup([]);
+
+		await CharacterCreationService.Instance().ensureDefaultItemsExist();
+
+		const creations = skillCreations(createSpy);
+		expect(creations).toHaveLength(2);
+		expect(creations.some((call) => (call[0] as { name: string }).name === "Sorcery")).toBe(true);
+		expect(creations.some((call) => (call[0] as { name: string }).name === "Conjuring")).toBe(true);
+	});
+
+	it("skips creation when both already exist", async () => {
+		const { createSpy } = setup([existingSkillItem("Sorcery", "willpower"), existingSkillItem("Conjuring", "charisma")]);
+
+		await CharacterCreationService.Instance().ensureDefaultItemsExist();
+
+		expect(skillCreations(createSpy)).toHaveLength(0);
+	});
+});

--- a/module/services/character-creation/CharacterCreationService.ts
+++ b/module/services/character-creation/CharacterCreationService.ts
@@ -8,6 +8,8 @@ import { MetatypeRepository, type MetatypeOption } from "./MetatypeRepository";
 import { MagicRepository, type MagicOption } from "./MagicRepository";
 import { PriorityValidator, type SelectedPriorities, type ValidationResult } from "./PriorityValidator";
 import { CharacterInitializer, type CharacterCreationSelections } from "./CharacterInitializer";
+import { SkillRepository } from "./SkillRepository";
+import { localize } from "../utilities";
 import type SR3EActor from "../../documents/SR3EActor";
 
 /**
@@ -38,6 +40,7 @@ export class CharacterCreationService {
 
 	#metatypeRepo: MetatypeRepository;
 	#magicRepo: MagicRepository;
+	#skillRepo: SkillRepository;
 	#validator: PriorityValidator;
 	#initializer: CharacterInitializer;
 
@@ -46,6 +49,7 @@ export class CharacterCreationService {
 	private constructor() {
 		this.#metatypeRepo = MetatypeRepository.Instance();
 		this.#magicRepo = MagicRepository.Instance();
+		this.#skillRepo = SkillRepository.Instance();
 		this.#validator = PriorityValidator.Instance();
 		this.#initializer = CharacterInitializer.Instance();
 	}
@@ -108,6 +112,46 @@ export class CharacterCreationService {
 			const magicData = this.#magicRepo.getDefaultMagic();
 			await Item.create(magicData);
 		}
+
+		// Ensure Sorcery/Conjuring skill items exist — magician archetypes are entitled
+		// to them, so the world must always have them available to draw on.
+		await this.#ensureMagicSkillsExist();
+	}
+
+	/**
+	 * Ensures the Sorcery and Conjuring skill catalog items exist in the world,
+	 * creating and localizing whichever is missing.
+	 */
+	async #ensureMagicSkillsExist(): Promise<void> {
+		const activeSkills = this.#skillRepo.getSkillsByCategory("active");
+		const sorceryName = localize(CONFIG.SR3E.SKILL.sorcery);
+		const conjuringName = localize(CONFIG.SR3E.SKILL.conjuring);
+
+		if (!activeSkills.some((s) => s.name === sorceryName)) {
+			console.log("SR3E | No Sorcery skill found, creating default");
+			await Item.create(this.#buildMagicSkillData(sorceryName, "willpower"));
+		}
+
+		if (!activeSkills.some((s) => s.name === conjuringName)) {
+			console.log("SR3E | No Conjuring skill found, creating default");
+			await Item.create(this.#buildMagicSkillData(conjuringName, "charisma"));
+		}
+	}
+
+	#buildMagicSkillData(name: string, linkedAttribute: string): Record<string, unknown> {
+		return {
+			name,
+			type: "skill",
+			system: {
+				skillType: "active",
+				activeSkill: {
+					value: 0,
+					linkedAttribute,
+					associatedDicePool: "",
+					specializations: [],
+				},
+			},
+		};
 	}
 
 	/**

--- a/module/services/character-creation/CharacterInitializer.test.ts
+++ b/module/services/character-creation/CharacterInitializer.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it, vi } from "vitest";
+import { CharacterInitializer, type CharacterCreationSelections } from "./CharacterInitializer";
+
+(globalThis as Record<string, unknown>).CONFIG = { SR3E: { TRANSACTION: { startingcreditstick: "sr3e.transaction.startingcreditstick" } } };
+
+function skillTemplate(id: string, category: "active" | "knowledge" | "language", linkedAttribute: string) {
+	const categoryField = `${category}Skill`;
+	return {
+		id,
+		toObject: () => ({
+			name: id,
+			type: "skill",
+			system: { skillType: category, [categoryField]: { value: 0, linkedAttribute, specializations: [] } },
+		}),
+		system: { [categoryField]: { linkedAttribute } },
+	};
+}
+
+const worldItems: Record<string, unknown> = {
+	"skill-pistols": skillTemplate("skill-pistols", "active", "quickness"),
+	"skill-streetwise": skillTemplate("skill-streetwise", "knowledge", "intelligence"),
+	"skill-english": skillTemplate("skill-english", "language", "intelligence"),
+};
+
+(globalThis as Record<string, unknown>).game = {
+	i18n: { localize: (key: string) => key },
+	items: { get: (id: string) => worldItems[id] ?? { toObject: () => ({ name: "Human" }) } },
+};
+
+function actor() {
+	return {
+		update: vi.fn().mockResolvedValue(undefined),
+		createEmbeddedDocuments: vi.fn().mockResolvedValue(undefined),
+		setFlag: vi.fn().mockResolvedValue(undefined),
+	};
+}
+
+function baseSelections(): CharacterCreationSelections {
+	return {
+		metatypeId: "metatype1",
+		magicId: "magic1",
+		attributePriority: "C",
+		skillPriority: "C",
+		resourcePriority: "E",
+		age: 25,
+		height: 175,
+		weight: 75,
+	};
+}
+
+describe("CharacterInitializer.initializeCharacter", () => {
+	it("initializes all attributes to 1 and the pool to points-6 when no attributes were generated", async () => {
+		const testActor = actor();
+
+		await CharacterInitializer.Instance().initializeCharacter(testActor as never, baseSelections());
+
+		const updateData = testActor.update.mock.calls[0]![0] as Record<string, unknown>;
+		expect(updateData["system.attributes.strength.value"]).toBe(1);
+		expect(updateData["system.attributes.quickness.value"]).toBe(1);
+		expect(updateData["system.attributes.body.value"]).toBe(1);
+		expect(updateData["system.attributes.charisma.value"]).toBe(1);
+		expect(updateData["system.attributes.intelligence.value"]).toBe(1);
+		expect(updateData["system.attributes.willpower.value"]).toBe(1);
+		expect(updateData["system.creation.attributePoints"]).toBe(24 - 6);
+		expect(updateData["system.creation.knowledgePoints"]).toBeUndefined();
+		expect(updateData["system.creation.languagePoints"]).toBeUndefined();
+		expect(testActor.setFlag).toHaveBeenCalledWith("sr3e", "attributeAssignmentLocked", false);
+	});
+
+	it("initializes attributes to the generated roll and zeroes the pool when attributes were generated", async () => {
+		const testActor = actor();
+		const selections = {
+			...baseSelections(),
+			generatedAttributes: {
+				strength: 3,
+				quickness: 4,
+				body: 2,
+				charisma: 5,
+				intelligence: 6,
+				willpower: 4,
+			},
+		};
+
+		await CharacterInitializer.Instance().initializeCharacter(testActor as never, selections);
+
+		const updateData = testActor.update.mock.calls[0]![0] as Record<string, unknown>;
+		expect(updateData["system.attributes.strength.value"]).toBe(3);
+		expect(updateData["system.attributes.quickness.value"]).toBe(4);
+		expect(updateData["system.attributes.body.value"]).toBe(2);
+		expect(updateData["system.attributes.charisma.value"]).toBe(5);
+		expect(updateData["system.attributes.intelligence.value"]).toBe(6);
+		expect(updateData["system.attributes.willpower.value"]).toBe(4);
+		expect(updateData["system.creation.attributePoints"]).toBe(0);
+		expect(updateData["system.creation.knowledgePoints"]).toBe(6 * 5);
+		expect(updateData["system.creation.languagePoints"]).toBe(Math.floor(6 * 1.5));
+		expect(testActor.setFlag).toHaveBeenCalledWith("sr3e", "attributeAssignmentLocked", true);
+	});
+
+	it("embeds ticked skills at their rolled ratings and sets pools to the real remainder", async () => {
+		const testActor = actor();
+		const selections = {
+			...baseSelections(),
+			generatedAttributes: {
+				strength: 3,
+				quickness: 5,
+				body: 2,
+				charisma: 3,
+				intelligence: 4,
+				willpower: 3,
+			},
+			skillSelections: [
+				{ skillItemId: "skill-pistols", category: "active" as const, rating: 3 },
+				{ skillItemId: "skill-streetwise", category: "knowledge" as const, rating: 2 },
+				{ skillItemId: "skill-english", category: "language" as const, rating: 1 },
+			],
+		};
+
+		await CharacterInitializer.Instance().initializeCharacter(testActor as never, selections);
+
+		const updateData = testActor.update.mock.calls[0]![0] as Record<string, unknown>;
+		// Pistols: linked to Quickness (5), rating 3 -> all 3 levels below 5 -> cost 1 each -> spent 3
+		const activePool = Math.floor(34 * 0.6); // skillPriority C -> 34 total, 60% active
+		expect(updateData["system.creation.activePoints"]).toBe(activePool - 3);
+		// Streetwise: linked to Intelligence (4), rating 2 -> both levels below 4 -> cost 1 each -> spent 2
+		expect(updateData["system.creation.knowledgePoints"]).toBe(4 * 5 - 2);
+		// English: linked to Intelligence (4), rating 1 -> 1 level below 4 -> cost 1 -> spent 1
+		expect(updateData["system.creation.languagePoints"]).toBe(Math.floor(4 * 1.5) - 1);
+
+		const skillEmbedCall = testActor.createEmbeddedDocuments.mock.calls.find((call) =>
+			(call[1] as Array<{ type: string }>).some((item) => item.type === "skill")
+		);
+		const embeddedSkills = skillEmbedCall![1] as Array<{ name: string; system: Record<string, { value: number }> }>;
+		expect(embeddedSkills).toHaveLength(3);
+		expect(embeddedSkills.find((s) => s.name === "skill-pistols")?.system["activeSkill"]?.value).toBe(3);
+		expect(embeddedSkills.find((s) => s.name === "skill-streetwise")?.system["knowledgeSkill"]?.value).toBe(2);
+		expect(embeddedSkills.find((s) => s.name === "skill-english")?.system["languageSkill"]?.value).toBe(1);
+	});
+
+	it("does not touch skill pools or embed skills when no skills were selected", async () => {
+		const testActor = actor();
+
+		await CharacterInitializer.Instance().initializeCharacter(testActor as never, baseSelections());
+
+		const skillEmbedCall = testActor.createEmbeddedDocuments.mock.calls.find((call) =>
+			(call[1] as Array<{ type: string }>).some((item) => item.type === "skill")
+		);
+		expect(skillEmbedCall).toBeUndefined();
+	});
+
+	it("burns all four creation point pools to zero when burnUnusedPoints is set, even with no rolls", async () => {
+		const testActor = actor();
+		const selections = { ...baseSelections(), burnUnusedPoints: true };
+
+		await CharacterInitializer.Instance().initializeCharacter(testActor as never, selections);
+
+		const updateData = testActor.update.mock.calls[0]![0] as Record<string, unknown>;
+		expect(updateData["system.creation.attributePoints"]).toBe(0);
+		expect(updateData["system.creation.activePoints"]).toBe(0);
+		expect(updateData["system.creation.knowledgePoints"]).toBe(0);
+		expect(updateData["system.creation.languagePoints"]).toBe(0);
+		expect(testActor.setFlag).toHaveBeenCalledWith("sr3e", "attributeAssignmentLocked", true);
+	});
+
+	it("burns leftover points even when attributes/skills were partially rolled", async () => {
+		const testActor = actor();
+		const selections = {
+			...baseSelections(),
+			generatedAttributes: {
+				strength: 3,
+				quickness: 5,
+				body: 2,
+				charisma: 3,
+				intelligence: 4,
+				willpower: 3,
+			},
+			skillSelections: [{ skillItemId: "skill-pistols", category: "active" as const, rating: 3 }],
+			burnUnusedPoints: true,
+		};
+
+		await CharacterInitializer.Instance().initializeCharacter(testActor as never, selections);
+
+		const updateData = testActor.update.mock.calls[0]![0] as Record<string, unknown>;
+		expect(updateData["system.creation.attributePoints"]).toBe(0);
+		expect(updateData["system.creation.activePoints"]).toBe(0);
+		expect(updateData["system.creation.knowledgePoints"]).toBe(0);
+		expect(updateData["system.creation.languagePoints"]).toBe(0);
+	});
+});

--- a/module/services/character-creation/CharacterInitializer.ts
+++ b/module/services/character-creation/CharacterInitializer.ts
@@ -8,6 +8,8 @@ import type SR3EActor from "../../documents/SR3EActor";
 import { CreationPointsService } from "./CreationPointsService";
 import { FLAGS } from "../../constants/flags";
 import { localize } from "../utilities";
+import type { AttributeValues, BuyableAttributeKey } from "./AttributeRandomizerService";
+import { totalCostForRating, type SkillSelection } from "./SkillRandomizerService";
 
 // Type definitions for character creation
 
@@ -20,6 +22,9 @@ export interface CharacterCreationSelections {
 	age: number;
 	height: number;
 	weight: number;
+	generatedAttributes?: AttributeValues;
+	skillSelections?: SkillSelection[];
+	burnUnusedPoints?: boolean;
 }
 
 /**
@@ -75,24 +80,51 @@ export class CharacterInitializer {
 		const pointsService = CreationPointsService.Instance();
 
 		// Step 2: Prepare actor update data
+		const generated = selections.generatedAttributes;
+		const skillSelections = selections.skillSelections ?? [];
+		const activeSkillPool = pointsService.getDistributedSkillPoints(skillPoints, "active");
+		const remainders = this.#computeSkillPoolRemainders(skillSelections, generated, activeSkillPool);
+
+		// Creation points (attribute points minus 6 initial for base stats, skill points from priority table).
+		// Knowledge/language pools are normally calculated from final Intelligence at attribute-lock time
+		// (AttributePointsState's lock-modal confirm), not here. If the player used the Attribute
+		// Randomizer, the pool is fully spent (0) and that lock already happened implicitly, so the
+		// same knowledge/language derivation runs immediately instead of waiting on the modal.
+		let finalAttributePoints = generated ? 0 : attributePoints! - 6;
+		// Skill pools default to the full priority-derived amount, then get overridden with the real
+		// remainder if the player rolled skills (NOT forced to 0 — specialization assignment stays a
+		// manual step, so the unspent-points gate must reflect reality) unless burnUnusedPoints below.
+		let finalActivePoints = remainders.active ?? activeSkillPool;
+		let finalKnowledgePoints = generated ? (remainders.knowledge ?? generated.intelligence * 5) : undefined;
+		let finalLanguagePoints = generated ? (remainders.language ?? Math.floor(generated.intelligence * 1.5)) : undefined;
+
+		// Extended-randomization option: discard whatever's left in every pool, spent or not.
+		if (selections.burnUnusedPoints) {
+			finalAttributePoints = 0;
+			finalActivePoints = 0;
+			finalKnowledgePoints = 0;
+			finalLanguagePoints = 0;
+		}
+
 		const updateData: Record<string, unknown> = {
 			// Profile data
 			"system.profile.age": selections.age,
 			"system.profile.height": selections.height,
 			"system.profile.weight": selections.weight,
 
-			// Creation points (attribute points minus 6 initial for base stats, skill points from priority table)
-			// Knowledge/language pools are calculated from final Intelligence at attribute-lock time, not here
-			"system.creation.attributePoints": attributePoints! - 6,
-			"system.creation.activePoints": pointsService.getDistributedSkillPoints(skillPoints, "active"),
+			"system.creation.attributePoints": finalAttributePoints,
+			"system.creation.activePoints": finalActivePoints,
+			...(finalKnowledgePoints !== undefined ? { "system.creation.knowledgePoints": finalKnowledgePoints } : {}),
+			...(finalLanguagePoints !== undefined ? { "system.creation.languagePoints": finalLanguagePoints } : {}),
 
-			// Initialize all attributes to 1, essence to 6
-			"system.attributes.strength.value": 1,
-			"system.attributes.quickness.value": 1,
-			"system.attributes.body.value": 1,
-			"system.attributes.charisma.value": 1,
-			"system.attributes.intelligence.value": 1,
-			"system.attributes.willpower.value": 1,
+			// Initialize attributes to the randomizer's roll if the player used it, otherwise the 1-each baseline.
+			// Essence always starts at the racial maximum of 6, independent of attribute-point spending.
+			"system.attributes.strength.value": generated?.strength ?? 1,
+			"system.attributes.quickness.value": generated?.quickness ?? 1,
+			"system.attributes.body.value": generated?.body ?? 1,
+			"system.attributes.charisma.value": generated?.charisma ?? 1,
+			"system.attributes.intelligence.value": generated?.intelligence ?? 1,
+			"system.attributes.willpower.value": generated?.willpower ?? 1,
 			"system.attributes.essence.value": 6,
 
 			// Initialize karma pool
@@ -105,6 +137,14 @@ export class CharacterInitializer {
 		// Step 4: Create embedded metatype item
 		const metatypeItem = game.items?.get(selections.metatypeId)!;
 		await actor.createEmbeddedDocuments("Item", [metatypeItem.toObject()]);
+
+		// Step 4b: Create embedded copies of every ticked skill at its rolled rating
+		if (skillSelections.length > 0) {
+			const skillItems = skillSelections
+				.map((selection) => this.#buildTickedSkillData(selection))
+				.filter((data): data is Record<string, unknown> => data !== null);
+			if (skillItems.length > 0) await actor.createEmbeddedDocuments("Item", skillItems);
+		}
 
 		// Step 5: Create starting resources as a credit stick
 		await actor.createEmbeddedDocuments("Item", [this.#startingCreditStick(selections.resourcePriority)]);
@@ -123,9 +163,16 @@ export class CharacterInitializer {
 			await actor.update({ "system.attributes.magic.value": 6 });
 		}
 
-		// Step 7: Set character creation mode flags
+		// Step 7: Set character creation mode flags.
+		// A randomized attribute roll — or burning unused points outright — counts as an implicit
+		// lock-in — skip the "spend your attribute points" phase (and its lock-confirmation modal)
+		// and go straight to skill assignment.
 		await actor.setFlag(configkeys.sr3e, FLAGS.ACTOR.IS_CHARACTER_CREATION, true);
-		await actor.setFlag(configkeys.sr3e, FLAGS.ACTOR.ATTRIBUTE_ASSIGNMENT_LOCKED, false);
+		await actor.setFlag(
+			configkeys.sr3e,
+			FLAGS.ACTOR.ATTRIBUTE_ASSIGNMENT_LOCKED,
+			!!generated || !!selections.burnUnusedPoints
+		);
 
 		console.log("SR3E | Character initialized in creation mode");
 	}
@@ -150,6 +197,71 @@ export class CharacterInitializer {
 
 		const priority = (magicItem.system as { awakened?: { priority?: string } })?.awakened?.priority;
 		return priority ?? "E";
+	}
+
+	/**
+	 * Computes the real remaining points in each skill pool after the rolled selections'
+	 * cost is subtracted from the priority-derived total. Returns undefined for a category
+	 * with no selections, so the caller can fall back to the un-rolled default.
+	 */
+	#computeSkillPoolRemainders(
+		skillSelections: SkillSelection[],
+		generated: AttributeValues | undefined,
+		activeSkillPool: number
+	): { active?: number; knowledge?: number; language?: number } {
+		const remainders: { active?: number; knowledge?: number; language?: number } = {};
+		if (skillSelections.length === 0) return remainders;
+
+		const totals: Record<SkillSelection["category"], number> = {
+			active: activeSkillPool,
+			knowledge: generated ? generated.intelligence * 5 : 0,
+			language: generated ? Math.floor(generated.intelligence * 1.5) : 0,
+		};
+		const spent: Record<SkillSelection["category"], number> = { active: 0, knowledge: 0, language: 0 };
+
+		for (const selection of skillSelections) {
+			const linkedAttrRating = this.#linkedAttrRatingFor(selection, generated);
+			spent[selection.category] += totalCostForRating(selection.rating, linkedAttrRating);
+		}
+
+		const touchedCategories = new Set(skillSelections.map((s) => s.category));
+		for (const category of touchedCategories) {
+			remainders[category] = totals[category] - spent[category];
+		}
+
+		return remainders;
+	}
+
+	/**
+	 * Linked-attribute rating for a ticked skill: for active skills, the final rolled value
+	 * of the skill's own linked attribute; for knowledge/language, always Intelligence.
+	 */
+	#linkedAttrRatingFor(selection: SkillSelection, generated: AttributeValues | undefined): number {
+		if (!generated) return 1;
+		if (selection.category !== "active") return generated.intelligence;
+
+		const skillItem = game.items?.get(selection.skillItemId);
+		const linkedAttribute = (skillItem?.system as { activeSkill?: { linkedAttribute?: string } })?.activeSkill
+			?.linkedAttribute as BuyableAttributeKey | undefined;
+		return (linkedAttribute && generated[linkedAttribute]) ?? 1;
+	}
+
+	/**
+	 * Builds embedded-item data for a ticked skill: a copy of its catalog template with
+	 * the rolled rating written into the category-appropriate value field.
+	 */
+	#buildTickedSkillData(selection: SkillSelection): Record<string, unknown> | null {
+		const template = game.items?.get(selection.skillItemId);
+		if (!template) return null;
+
+		const data = template.toObject() as Record<string, unknown>;
+		const system = { ...(data.system as Record<string, unknown>) };
+		const categoryField = { ...(system[`${selection.category}Skill`] as Record<string, unknown>) };
+		categoryField.value = selection.rating;
+		system[`${selection.category}Skill`] = categoryField;
+		data.system = system;
+
+		return data;
 	}
 
 	#startingCreditStick(resourcePriority: string): Record<string, unknown> {

--- a/module/services/character-creation/MagicSkillAccess.test.ts
+++ b/module/services/character-creation/MagicSkillAccess.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { getMagicSkillAccess } from "./MagicSkillAccess";
+
+describe("getMagicSkillAccess", () => {
+	it("gives adepts neither skill", () => {
+		expect(getMagicSkillAccess({ archetype: "adept" })).toEqual({ sorcery: false, conjuring: false });
+	});
+
+	it("gives fullmages both skills", () => {
+		expect(getMagicSkillAccess({ archetype: "magician", magicianType: "fullmage" })).toEqual({
+			sorcery: true,
+			conjuring: true,
+		});
+	});
+
+	it("gives sorcerer-aspected mages Sorcery only", () => {
+		expect(
+			getMagicSkillAccess({ archetype: "magician", magicianType: "aspectedmage", aspect: "sorcerer" })
+		).toEqual({ sorcery: true, conjuring: false });
+	});
+
+	it("gives conjurer-aspected mages Conjuring only", () => {
+		expect(
+			getMagicSkillAccess({ archetype: "magician", magicianType: "aspectedmage", aspect: "conjurer" })
+		).toEqual({ sorcery: false, conjuring: true });
+	});
+
+	it("gives elementalist-aspected mages both skills", () => {
+		expect(
+			getMagicSkillAccess({ archetype: "magician", magicianType: "aspectedmage", aspect: "elementalist" })
+		).toEqual({ sorcery: true, conjuring: true });
+	});
+
+	it("gives custom-aspected mages both skills", () => {
+		expect(
+			getMagicSkillAccess({ archetype: "magician", magicianType: "aspectedmage", aspect: "custom" })
+		).toEqual({ sorcery: true, conjuring: true });
+	});
+
+	it("gives Unawakened (no archetype) neither skill", () => {
+		expect(getMagicSkillAccess(undefined)).toEqual({ sorcery: false, conjuring: false });
+		expect(getMagicSkillAccess({})).toEqual({ sorcery: false, conjuring: false });
+	});
+});

--- a/module/services/character-creation/MagicSkillAccess.ts
+++ b/module/services/character-creation/MagicSkillAccess.ts
@@ -1,0 +1,40 @@
+/**
+ * Pure mapping from a magic item's archetype/magicianType/aspect to whether the
+ * character has access to the Sorcery and/or Conjuring skills. No Actor/Foundry
+ * dependency — takes plain data in, returns plain data out.
+ */
+
+export interface MagicAccessData {
+	archetype?: string;
+	magicianType?: string;
+	aspect?: string;
+}
+
+export interface MagicSkillAccess {
+	sorcery: boolean;
+	conjuring: boolean;
+}
+
+const NO_ACCESS: MagicSkillAccess = { sorcery: false, conjuring: false };
+const FULL_ACCESS: MagicSkillAccess = { sorcery: true, conjuring: true };
+
+/**
+ * Determines Sorcery/Conjuring access from a magic item's system data.
+ * Adepts get neither. Fullmages get both. Aspected mages get the skill matching
+ * their aspect (sorcerer -> Sorcery, conjurer -> Conjuring), or both for
+ * elementalist/custom aspects. Unawakened (no archetype) gets neither.
+ */
+export function getMagicSkillAccess(magic: MagicAccessData | undefined): MagicSkillAccess {
+	if (!magic?.archetype || magic.archetype === "adept") return NO_ACCESS;
+	if (magic.archetype !== "magician") return NO_ACCESS;
+	if (magic.magicianType !== "aspectedmage") return FULL_ACCESS;
+
+	switch (magic.aspect) {
+		case "sorcerer":
+			return { sorcery: true, conjuring: false };
+		case "conjurer":
+			return { sorcery: false, conjuring: true };
+		default:
+			return FULL_ACCESS;
+	}
+}

--- a/module/services/character-creation/SkillRandomizerService.test.ts
+++ b/module/services/character-creation/SkillRandomizerService.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { randomizeSkills, totalCostForRating, type TickedSkill } from "./SkillRandomizerService";
+
+function skills(count: number, linkedAttrRating: number): TickedSkill[] {
+	return Array.from({ length: count }, (_, i) => ({ id: `skill-${i}`, linkedAttrRating }));
+}
+
+describe("randomizeSkills", () => {
+	it("never exceeds the rating cap of 6", () => {
+		const result = randomizeSkills(100, skills(3, 4));
+
+		for (const rating of Object.values(result)) {
+			expect(rating).toBeLessThanOrEqual(6);
+		}
+	});
+
+	it("never spends more than the pool (1-point cost below linked attribute)", () => {
+		// All skills start below their linked attribute rating (4), so every point costs 1
+		// until a skill reaches rating 4, after which it costs 2.
+		const pool = 10;
+		const result = randomizeSkills(pool, skills(3, 4));
+
+		let spent = 0;
+		for (const rating of Object.values(result)) {
+			for (let r = 0; r < rating; r++) {
+				spent += r < 4 ? 1 : 2;
+			}
+		}
+		expect(spent).toBeLessThanOrEqual(pool);
+	});
+
+	it("applies the 1-vs-2 cost step relative to each skill's linked attribute rating", () => {
+		// Single skill, linked attribute rating 2, pool of 5.
+		// Points 1-2 cost 1 each (rating 0->1, 1->2), point 3+ costs 2 each (rating >= 2).
+		// Total affordable: 1+1+2 = 4 (rating 3), remaining 1 point can't afford the next (cost 2).
+		const result = randomizeSkills(5, [{ id: "only", linkedAttrRating: 2 }]);
+		expect(result.only).toBe(3);
+	});
+
+	it("is deterministic under an injected RNG", () => {
+		const scripted = [0, 0.99, 0.5, 0.2, 0.8, 0.1];
+		let call = 0;
+		const rng = () => scripted[call++ % scripted.length]!;
+
+		const first = randomizeSkills(10, skills(4, 3), rng);
+		call = 0;
+		const second = randomizeSkills(10, skills(4, 3), rng);
+
+		expect(first).toEqual(second);
+	});
+
+	it("allows a ticked skill to end at rating 0 when the pool can't reach it", () => {
+		// Pool of 0 — no skill should ever be funded.
+		const result = randomizeSkills(0, skills(3, 4));
+
+		for (const rating of Object.values(result)) {
+			expect(rating).toBe(0);
+		}
+	});
+
+	it("includes every ticked skill in the result, even unfunded ones", () => {
+		const result = randomizeSkills(1, skills(5, 4));
+		expect(Object.keys(result)).toHaveLength(5);
+	});
+});
+
+describe("totalCostForRating", () => {
+	it("sums 1 point per level below the linked attribute rating", () => {
+		expect(totalCostForRating(3, 6)).toBe(3);
+	});
+
+	it("sums 2 points per level at or above the linked attribute rating", () => {
+		// linkedAttrRating 2: levels 0,1 cost 1 each; levels 2,3 cost 2 each
+		expect(totalCostForRating(4, 2)).toBe(1 + 1 + 2 + 2);
+	});
+
+	it("costs nothing for rating 0", () => {
+		expect(totalCostForRating(0, 6)).toBe(0);
+	});
+});

--- a/module/services/character-creation/SkillRandomizerService.ts
+++ b/module/services/character-creation/SkillRandomizerService.ts
@@ -1,0 +1,71 @@
+/**
+ * Pure allocation algorithm for randomizing skill points during character creation.
+ * Takes plain data in, returns plain data out — no Actor, store, or Foundry API dependency.
+ *
+ * Cost rule (matches SkillSpendingService's runtime cost formula):
+ *   cost = currentRating < linkedAttrRating ? 1 : 2
+ *
+ * Unlike attributes, skills have no baseline floor — a ticked skill can legitimately
+ * end at rating 0 if the pool runs out before it's ever picked.
+ */
+
+export interface TickedSkill {
+	id: string;
+	linkedAttrRating: number;
+}
+
+export interface SkillSelection {
+	skillItemId: string;
+	category: "active" | "knowledge" | "language";
+	rating: number;
+}
+
+const MAX_SKILL_RATING = 6;
+
+function cost(currentRating: number, linkedAttrRating: number): number {
+	return currentRating < linkedAttrRating ? 1 : 2;
+}
+
+/**
+ * Total point cost to raise a skill from 0 to `rating`, summing each level's
+ * 1-vs-2 cost step. Used to compute the real remaining pool after a roll.
+ */
+export function totalCostForRating(rating: number, linkedAttrRating: number): number {
+	let total = 0;
+	for (let level = 0; level < rating; level++) total += cost(level, linkedAttrRating);
+	return total;
+}
+
+/**
+ * Randomly distributes pool points across ticked skills, one point at a time, to a
+ * randomly chosen skill that is both under the rating cap and affordable against the
+ * remaining pool. Stops when the pool is exhausted or no eligible skill remains.
+ *
+ * @param randomSource - Injectable RNG in [0, 1); defaults to Math.random. Pass a seeded
+ * generator in tests for deterministic assertions.
+ */
+export function randomizeSkills(
+	pool: number,
+	tickedSkills: TickedSkill[],
+	randomSource: () => number = Math.random
+): Record<string, number> {
+	const ratings: Record<string, number> = {};
+	for (const skill of tickedSkills) ratings[skill.id] = 0;
+
+	let remainingPool = pool;
+
+	while (remainingPool > 0) {
+		const eligible = tickedSkills.filter((skill) => {
+			const rating = ratings[skill.id]!;
+			return rating < MAX_SKILL_RATING && cost(rating, skill.linkedAttrRating) <= remainingPool;
+		});
+		if (eligible.length === 0) break;
+
+		const pick = eligible[Math.floor(randomSource() * eligible.length)]!;
+		const pickCost = cost(ratings[pick.id]!, pick.linkedAttrRating);
+		ratings[pick.id]!++;
+		remainingPool -= pickCost;
+	}
+
+	return ratings;
+}

--- a/module/services/character-creation/SkillRepository.ts
+++ b/module/services/character-creation/SkillRepository.ts
@@ -1,0 +1,56 @@
+/**
+ * Repository for querying skill items from Foundry's game.items collection.
+ * Provides data access for character creation skill selection.
+ */
+
+import type { SkillCategory } from "./SkillSpendingService";
+
+export interface SkillOption {
+	name: string;
+	foundryitemid: string;
+	category: SkillCategory;
+	linkedAttribute: string;
+}
+
+const LINKED_ATTRIBUTE_PATH: Record<SkillCategory, string> = {
+	active: "activeSkill",
+	knowledge: "knowledgeSkill",
+	language: "languageSkill",
+};
+
+/**
+ * Repository service for skill item data access.
+ * Follows the singleton pattern established by MetatypeRepository/MagicRepository.
+ */
+export class SkillRepository {
+	static #instance: SkillRepository | null = null;
+
+	static Instance(): SkillRepository {
+		if (!this.#instance) this.#instance = new SkillRepository();
+		return this.#instance;
+	}
+
+	/**
+	 * Queries game.items for all skill items of the given category.
+	 * @returns Array of skill options with name, id, category, and linked attribute
+	 */
+	getSkillsByCategory(category: SkillCategory): SkillOption[] {
+		const skills = game.items?.filter((item: Item) => item.type === "skill") ?? [];
+
+		return skills
+			.filter((item: Item) => {
+				const system = item.system as Record<string, unknown>;
+				return system?.skillType === category;
+			})
+			.map((item: Item) => {
+				const system = item.system as Record<string, Record<string, unknown>>;
+				const linkedAttribute = (system[LINKED_ATTRIBUTE_PATH[category]]?.linkedAttribute as string) ?? "";
+				return {
+					name: item.name,
+					foundryitemid: item.id!,
+					category,
+					linkedAttribute,
+				};
+			});
+	}
+}

--- a/module/sheets/actors/CharacterCreationApp.ts
+++ b/module/sheets/actors/CharacterCreationApp.ts
@@ -35,15 +35,15 @@ export class CharacterCreationApp extends foundry.applications.api.ApplicationV2
 
 	static override DEFAULT_OPTIONS = {
 		id: "sr3e-character-creation",
-		classes: ["sr3e", "sheet", "staticlayout", "charactercreation"],
+		classes: ["sr3e", "sheet", "charactercreation"],
 		tag: "form",
 		window: {
 			title: "Character Creation",
-			resizable: false,
+			resizable: true,
 		},
 		position: {
-			width: "auto",
-			height: "auto",
+			width: 900,
+			height: 800,
 		},
 	};
 

--- a/module/ui/dialogs/AttributeRandomizerComponent.svelte
+++ b/module/ui/dialogs/AttributeRandomizerComponent.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+import { PRIORITY_TABLES } from "../../../types/character-creation";
+import {
+   BUYABLE_ATTRIBUTES,
+   randomizeAttributes,
+   type AttributeValues,
+   type RacialLimits,
+} from "../../services/character-creation/AttributeRandomizerService";
+import { localize } from "../../services/utilities";
+import StatCard from "../actors/actor-components/StatCard.svelte";
+
+interface Props {
+   metatypeId: string;
+   attributePriority: string;
+   generatedAttributes: AttributeValues | null;
+   onRandomize?: () => void;
+   onClear?: () => void;
+}
+
+let {
+   metatypeId,
+   attributePriority,
+   generatedAttributes = $bindable(null),
+   onRandomize,
+   onClear,
+}: Props = $props();
+
+const localization = $derived(CONFIG.SR3E.ATTRIBUTES);
+
+const metatypeItem = $derived(
+   metatypeId ? (game.items?.get(metatypeId) as Item | undefined) : undefined,
+);
+
+const racialLimits = $derived(
+   (metatypeItem?.system as { attributeLimits?: RacialLimits })?.attributeLimits,
+);
+
+const totalPoints = $derived(
+   PRIORITY_TABLES.attributes.find((entry) => entry.priority === attributePriority)?.points,
+);
+
+// The priority's point total already counts the baseline 1 spent on each attribute
+// (mirrors CharacterInitializer's `attributePoints - 6`) — only the remainder is free to distribute.
+const pointsToDistribute = $derived(
+   totalPoints !== undefined ? totalPoints - BUYABLE_ATTRIBUTES.length : undefined,
+);
+
+const canRandomize = $derived(!!racialLimits && pointsToDistribute !== undefined);
+
+function handleRandomize(): void {
+   if (!racialLimits || pointsToDistribute === undefined) return;
+   generatedAttributes = randomizeAttributes(pointsToDistribute, racialLimits);
+   // A re-roll invalidates any skill points already spent against the old attribute
+   // values (their cost depends on the linked attribute's rating) — cascade the clear.
+   onRandomize?.();
+}
+
+function handleClear(): void {
+   generatedAttributes = null;
+   onClear?.();
+}
+</script>
+
+<div class="attribute-randomizer">
+   <div class="character-creation-buttonpanel">
+      <button type="button" disabled={!canRandomize} onclick={handleRandomize}>
+         <i class="fas fa-dice"></i>
+         Randomize
+      </button>
+
+      <button type="button" disabled={!generatedAttributes} onclick={handleClear}>
+         <i class="fas fa-eraser"></i>
+         Clear
+      </button>
+   </div>
+
+   {#if generatedAttributes}
+      <div class="attribute-grid">
+         {#each BUYABLE_ATTRIBUTES as key}
+            <StatCard label={localize(localization[key as keyof typeof localization])}>
+               <span class="attribute-value">{generatedAttributes[key]}</span>
+            </StatCard>
+         {/each}
+      </div>
+   {/if}
+</div>

--- a/module/ui/dialogs/CharacterCreationDialog.svelte
+++ b/module/ui/dialogs/CharacterCreationDialog.svelte
@@ -5,10 +5,15 @@
       PRIORITY_TABLES,
    } from "../../../types/character-creation";
    import { untrack } from "svelte";
-   import ItemSheetWrapper from "../common-components/ItemSheetWrapper.svelte";
-   import ItemSheetComponent from "../common-components/ItemSheetComponent.svelte";
+   import SheetCard from "../common-components/SheetCard.svelte";
+   import PackeryGrid from "../common-components/PackeryGrid.svelte";
    import LabeledDropdown from "../items/LabeledDropdown.svelte";
+   import LabeledBoolean from "../items/LabeledBoolean.svelte";
    import { pickImagePath } from "../../services/utilities";
+   import AttributeRandomizerComponent from "./AttributeRandomizerComponent.svelte";
+   import type { AttributeValues } from "../../services/character-creation/AttributeRandomizerService";
+   import SkillCategoryChecklist from "./SkillCategoryChecklist.svelte";
+   import type { SkillSelection } from "../../services/character-creation/SkillRandomizerService";
 
    const { actorName: _actorName, onSubmit, onCancel } = $props<{
       actorName: string;
@@ -28,6 +33,18 @@
    let selectedAttribute = $state("");
    let selectedSkill = $state("");
    let selectedResource = $state("");
+   let extendedRandomization = $state(false);
+   let burnUnusedPoints = $state(false);
+   let generatedAttributes = $state<AttributeValues | null>(null);
+   let activeSkillSelections = $state<SkillSelection[]>([]);
+   let knowledgeSkillSelections = $state<SkillSelection[]>([]);
+   let languageSkillSelections = $state<SkillSelection[]>([]);
+   let skillsResetKey = $state(0);
+   const skillSelections = $derived([
+      ...activeSkillSelections,
+      ...knowledgeSkillSelections,
+      ...languageSkillSelections,
+   ]);
    const metatypeOptions = creationService.getMetatypes();
    const magicOptions = creationService.getMagics();
    const canCreate = $derived(
@@ -79,6 +96,12 @@
       if (selectedResource) arr.push(selectedResource);
       usedPriorities = arr;
    });
+
+   $effect(() => {
+      selectedMetatype;
+      selectedAttribute;
+      generatedAttributes = null;
+   });
    function handleSubmit(event: Event) {
       event.preventDefault();
       onSubmit({
@@ -92,6 +115,9 @@
          age: characterAge,
          height: characterHeight,
          weight: characterWeight,
+         generatedAttributes: generatedAttributes ?? undefined,
+         skillSelections: skillSelections.length > 0 ? skillSelections : undefined,
+         burnUnusedPoints: extendedRandomization && burnUnusedPoints ? true : undefined,
       });
    }
 
@@ -147,12 +173,33 @@
       characterAge = 25;
       characterHeight = 175;
       characterWeight = 75;
+      clearSkillSelections();
+      generatedAttributes = null;
+      burnUnusedPoints = false;
+   }
+
+   // Skills are randomized against final attribute values, so clearing attributes
+   // invalidates any skill roll — cascade the clear and hide the skill sections again.
+   function clearSkillSelections() {
+      activeSkillSelections = [];
+      knowledgeSkillSelections = [];
+      languageSkillSelections = [];
+      skillsResetKey++;
+   }
+
+   function handleExtendedRandomizationChange(enabled: boolean) {
+      extendedRandomization = enabled;
+      if (!enabled) {
+         clearSkillSelections();
+         generatedAttributes = null;
+         burnUnusedPoints = false;
+      }
    }
 </script>
 
 <form onsubmit={handleSubmit}>
-   <ItemSheetWrapper csslayout="double">
-      <ItemSheetComponent>
+   <PackeryGrid>
+      <SheetCard>
          <div class="image-mask">
             <img
                src={characterImage}
@@ -172,8 +219,8 @@
                placeholder="Enter character name"
             />
          </div>
-      </ItemSheetComponent>
-      <ItemSheetComponent>
+      </SheetCard>
+      <SheetCard>
          <div class="stat-grid single-column">
             <div class="stat-card stat-field-card labeled-slider">
                <div class="stat-card-background"></div>
@@ -226,8 +273,11 @@
                </div>
             </div>
          </div>
-      </ItemSheetComponent>
-      <ItemSheetComponent>
+      </SheetCard>
+      <SheetCard>
+         <div class="title-container">
+            <h4 class="no-margin uppercase">Priority</h4>
+         </div>
          <div class="stat-grid single-column">
             <LabeledDropdown
                key="metatype"
@@ -327,20 +377,90 @@
                   </select>
                </div>
             </div>
+
+            <LabeledBoolean
+               key="extendedRandomization"
+               label="Extended Randomization"
+               value={extendedRandomization}
+               onUpdate={handleExtendedRandomizationChange}
+            />
+
+            {#if extendedRandomization}
+               <LabeledBoolean
+                  key="burnUnusedPoints"
+                  label="Burn Unused Points"
+                  value={burnUnusedPoints}
+                  onUpdate={(val) => (burnUnusedPoints = val)}
+               />
+            {/if}
+
+            <div class="character-creation-buttonpanel">
+               <button type="button" onclick={handleRandomize}>
+                  <i class="fas fa-dice"></i>
+                  Randomize
+               </button>
+
+               <button type="button" onclick={handleClear}>
+                  <i class="fas fa-eraser"></i>
+                  Clear
+               </button>
+            </div>
          </div>
-      </ItemSheetComponent>
-      <ItemSheetComponent>
+      </SheetCard>
+      {#if extendedRandomization}
+         <SheetCard>
+            <div class="title-container">
+               <h4 class="no-margin uppercase">Attributes</h4>
+            </div>
+            <AttributeRandomizerComponent
+               metatypeId={selectedMetatype}
+               attributePriority={selectedAttribute}
+               bind:generatedAttributes
+               onRandomize={clearSkillSelections}
+               onClear={clearSkillSelections}
+            />
+         </SheetCard>
+         {#if generatedAttributes}
+            <SheetCard>
+               {#key skillsResetKey}
+                  <SkillCategoryChecklist
+                     category="active"
+                     label="Active"
+                     magicId={selectedMagic}
+                     skillPriority={selectedSkill}
+                     {generatedAttributes}
+                     bind:skillSelections={activeSkillSelections}
+                  />
+               {/key}
+            </SheetCard>
+            <SheetCard>
+               {#key skillsResetKey}
+                  <SkillCategoryChecklist
+                     category="knowledge"
+                     label="Knowledge"
+                     magicId={selectedMagic}
+                     skillPriority={selectedSkill}
+                     {generatedAttributes}
+                     bind:skillSelections={knowledgeSkillSelections}
+                  />
+               {/key}
+            </SheetCard>
+            <SheetCard>
+               {#key skillsResetKey}
+                  <SkillCategoryChecklist
+                     category="language"
+                     label="Language"
+                     magicId={selectedMagic}
+                     skillPriority={selectedSkill}
+                     {generatedAttributes}
+                     bind:skillSelections={languageSkillSelections}
+                  />
+               {/key}
+            </SheetCard>
+         {/if}
+      {/if}
+      <SheetCard>
          <div class="character-creation-buttonpanel">
-            <button type="button" onclick={handleRandomize}>
-               <i class="fas fa-dice"></i>
-               Randomize
-            </button>
-
-            <button type="button" onclick={handleClear}>
-               <i class="fas fa-eraser"></i>
-               Clear
-            </button>
-
             <button type="button" onclick={onCancel}>
                <i class="fas fa-times"></i>
                Cancel
@@ -351,6 +471,6 @@
                Create Character
             </button>
          </div>
-      </ItemSheetComponent>
-   </ItemSheetWrapper>
+      </SheetCard>
+   </PackeryGrid>
 </form>

--- a/module/ui/dialogs/SkillCategoryChecklist.svelte
+++ b/module/ui/dialogs/SkillCategoryChecklist.svelte
@@ -1,0 +1,137 @@
+<script lang="ts">
+import { untrack } from "svelte";
+import { SkillRepository, type SkillOption } from "../../services/character-creation/SkillRepository";
+import { getMagicSkillAccess } from "../../services/character-creation/MagicSkillAccess";
+import { randomizeSkills, type SkillSelection } from "../../services/character-creation/SkillRandomizerService";
+import { CreationPointsService } from "../../services/character-creation/CreationPointsService";
+import type { AttributeValues, BuyableAttributeKey } from "../../services/character-creation/AttributeRandomizerService";
+import type { SkillCategory } from "../../services/character-creation/SkillSpendingService";
+import { localize } from "../../services/utilities";
+import SkillRandomValueDisplay from "./SkillRandomValueDisplay.svelte";
+
+interface Props {
+   category: SkillCategory;
+   label: string;
+   magicId: string;
+   skillPriority: string;
+   generatedAttributes: AttributeValues | null;
+   skillSelections: SkillSelection[];
+}
+
+let {
+   category,
+   label,
+   magicId,
+   skillPriority,
+   generatedAttributes,
+   skillSelections = $bindable([]),
+}: Props = $props();
+
+const skillRepo = SkillRepository.Instance();
+const pointsService = CreationPointsService.Instance();
+
+const catalog: SkillOption[] = $derived(skillRepo.getSkillsByCategory(category));
+
+let ticked = $state<Record<string, boolean>>({});
+let ratings = $state<Record<string, number>>({});
+
+const magicItem = $derived(magicId ? (game.items?.get(magicId) as Item | undefined) : undefined);
+const magicAccess = $derived(
+   getMagicSkillAccess(magicItem?.system as { archetype?: string; magicianType?: string; aspect?: string } | undefined),
+);
+
+$effect(() => {
+   if (category !== "active") return;
+   const access = magicAccess;
+   const sorceryName = localize(CONFIG.SR3E.SKILL.sorcery);
+   const conjuringName = localize(CONFIG.SR3E.SKILL.conjuring);
+   const sorcery = catalog.find((s) => s.name === sorceryName);
+   const conjuring = catalog.find((s) => s.name === conjuringName);
+
+   // untrack the read of `ticked` — this effect must only re-run when magicAccess/catalog
+   // change, not whenever it writes ticked itself (that would be a self-triggering loop).
+   const next = { ...untrack(() => ticked) };
+   if (sorcery) next[sorcery.foundryitemid] = access.sorcery;
+   if (conjuring) next[conjuring.foundryitemid] = access.conjuring;
+   ticked = next;
+});
+
+const canRandomize = $derived(!!generatedAttributes);
+
+function pool(): number {
+   if (!generatedAttributes) return 0;
+   if (category === "active") {
+      const totalSkillPoints = pointsService.getTotalSkillPoints(skillPriority);
+      return pointsService.getDistributedSkillPoints(totalSkillPoints, "active");
+   }
+   if (category === "knowledge") return generatedAttributes.intelligence * 5;
+   return Math.floor(generatedAttributes.intelligence * 1.5);
+}
+
+function linkedAttrRatingFor(skill: SkillOption): number {
+   if (!generatedAttributes) return 0;
+   if (category !== "active") return generatedAttributes.intelligence;
+   return generatedAttributes[skill.linkedAttribute as BuyableAttributeKey] ?? 1;
+}
+
+function toggleSkill(skillId: string): void {
+   const isTicked = !!ticked[skillId];
+   ticked = { ...ticked, [skillId]: !isTicked };
+
+   const nextRatings = { ...ratings };
+   if (isTicked) delete nextRatings[skillId];
+   else nextRatings[skillId] = 0;
+   ratings = nextRatings;
+}
+
+function randomize(): void {
+   if (!generatedAttributes) return;
+
+   const tickedSkills = catalog
+      .filter((skill) => ticked[skill.foundryitemid])
+      .map((skill) => ({ id: skill.foundryitemid, linkedAttrRating: linkedAttrRatingFor(skill) }));
+
+   ratings = randomizeSkills(pool(), tickedSkills);
+}
+
+function clear(): void {
+   ticked = {};
+   ratings = {};
+}
+
+$effect(() => {
+   skillSelections = Object.entries(ratings).map(([skillItemId, rating]) => ({
+      skillItemId,
+      category,
+      rating,
+   }));
+});
+</script>
+
+<div class="skills-checklist-category">
+   <div class="title-container">
+      <h4 class="no-margin uppercase">{label} Skills</h4>
+   </div>
+
+   <div class="skills-checklist-list">
+      {#each catalog as skill (skill.foundryitemid)}
+         <SkillRandomValueDisplay
+            label={skill.name}
+            checked={!!ticked[skill.foundryitemid]}
+            value={ratings[skill.foundryitemid]}
+            onChange={() => toggleSkill(skill.foundryitemid)}
+         />
+      {/each}
+   </div>
+
+   <div class="character-creation-buttonpanel">
+      <button type="button" class:highlighted={canRandomize} disabled={!canRandomize} onclick={randomize}>
+         <i class="fas fa-dice"></i>
+         Randomize
+      </button>
+      <button type="button" onclick={clear}>
+         <i class="fas fa-eraser"></i>
+         Clear
+      </button>
+   </div>
+</div>

--- a/module/ui/dialogs/SkillRandomValueDisplay.svelte
+++ b/module/ui/dialogs/SkillRandomValueDisplay.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+import FieldLabel from "../common-components/FieldLabel.svelte";
+import Switch from "../common-components/Switch.svelte";
+
+let {
+    label,
+    checked,
+    value,
+    onChange,
+    disabled = false,
+}: {
+    label: string;
+    checked: boolean;
+    value?: number;
+    onChange: (checked: boolean) => void;
+    disabled?: boolean;
+} = $props();
+
+function handleChange(e: Event) {
+    onChange((e.target as HTMLInputElement).checked);
+}
+</script>
+
+<div class="stat-card stat-field-card labeled-field-card labeled-boolean" class:inactive={disabled}>
+    <div class="stat-card-background"></div>
+    <div class="title-container">
+        <FieldLabel {label} />
+    </div>
+    {#if value !== undefined}
+        <span class="skill-random-value">{value}</span>
+    {/if}
+    <Switch {checked} ariaLabel={label} onChange={handleChange} {disabled} />
+</div>

--- a/styles/actor/character-creation.scss
+++ b/styles/actor/character-creation.scss
@@ -1,7 +1,28 @@
 @use "../mixins.scss" as *;
 
+// Same "float outside the resize box" hack the character sheet uses (see character.scss's
+// form.application.sheet.sr3e.character rule): the window stays resizable, but its own box
+// doesn't clip content — cards can render past the nominal resize bounds for a nicer look.
+form.application.sheet.sr3e.charactercreation {
+  background: none;
+  overflow: visible;
+  max-height: 0rem;
+
+  section.window-content {
+    overflow: visible;
+
+    .packery-packery-grid {
+      overflow: visible;
+    }
+  }
+}
+
 // Character creation dialog — shares the sea-green stat-field-card / large-input-wrapper
 // language established by WeaponApp (see items/item-sheet.scss) rather than inventing its own.
+// Card layout uses the same PackeryGrid + SheetCard combo as the character sheet's own
+// top-level grid (CharacterSheetApp.svelte) — no dialog-specific packery CSS needed, the
+// shared .packery-grid-item / .packery-grid-sizer / .packery-gutter-sizer rules in
+// sheetcard.scss already cover it.
 .charactercreation {
   display: flex;
   flex-direction: column;
@@ -106,6 +127,17 @@
     }
   }
 
+  // Rolled skill rating — same blue as the stat-field-card header (.title-container h4),
+  // just applied to the number rather than the label.
+  .skill-random-value {
+    flex-shrink: 0;
+    margin: 0 0.5rem;
+    font-size: 0.9rem;
+    font-weight: bold;
+    color: var(--highlight-color-primary);
+    text-shadow: 0 0 6px rgba(0, 255, 200, 0.4);
+  }
+
   // Button panel — relies on the global button skin (skinning/core.scss); only lays out the grid.
   .character-creation-buttonpanel {
     display: grid;
@@ -116,6 +148,17 @@
     button.submit {
       grid-column: 1 / -1;
     }
+
+    // Draws attention to a Randomize button that just became available (e.g. skill
+    // randomizers unlocking once attributes have been rolled).
+    button.highlighted:not(:disabled) {
+      animation: pulse-glow-highlight 1.5s ease-in-out infinite;
+    }
+  }
+
+  @keyframes pulse-glow-highlight {
+    0%, 100% { box-shadow: 0 0 4px var(--highlight-color-primary); }
+    50%       { box-shadow: 0 0 12px var(--highlight-color-primary); }
   }
 
   @media (max-width: 768px) {


### PR DESCRIPTION
## Summary

Extends the character creation dialog with two optional randomizers, gated behind a new "Extended Randomization" priority toggle, plus a layout rework:

- **Attribute Randomizer** — rolls a legal attribute spread from the selected metatype's racial limits and attribute-priority point pool. Wired through `CharacterInitializer` so the generated values (and a fully-spent point pool) replace the default all-1s baseline on actor creation.
- **Skill Randomizer** — per-category (active/knowledge/language) tick-box checklists sourced from the world's skill catalog, with independent Randomize/Clear per category. Requires attributes to be rolled first, since skill point cost depends on final attribute ratings. Sorcery/Conjuring are auto-bootstrapped and pre-ticked per the character's magic archetype/aspect.
- **"Burn Unused Points"** — forces all four creation point pools to zero at creation time regardless of what was actually spent.
- Randomizing or clearing attributes cascades to clear any rolled skills, since their cost was computed against the old attribute values.
- Dialog layout reworked to use the same `PackeryGrid`/`SheetCard` true bin-packing layout, resizable window, and "float outside the resize box" visual treatment as the main character sheet.

## Test plan

- [x] `npx tsc --noEmit` clean on all touched files
- [x] `npx vite build` clean, no new warnings/errors
- [x] `npx vitest run` — 90/90 test files, 737/737 tests passing
- [x] Manual pass in a live Foundry world: roll attributes, roll skills per category, verify Sorcery/Conjuring pre-tick for a magician, toggle Burn Unused Points, resize the dialog window